### PR TITLE
Support for arbitrary target configuration

### DIFF
--- a/crate.nix
+++ b/crate.nix
@@ -54,14 +54,14 @@
     inherit rustc;
     inherit packageFun;
     rustPackageConfig = lib.recursiveUpdate config' {
-      features = features.${pkgs.stdenv.hostPlatform.config};
+      features = features.${pkgs.rustBuilder.rustLib.realHostTriple pkgs.stdenv.hostPlatform};
     };
     buildRustPackages = buildPackages.rustBuilder.makePackageSet {
       inherit cargo;
       inherit rustc;
       inherit packageFun;
       rustPackageConfig = lib.recursiveUpdate buildConfig' {
-        features = features.${buildPackages.stdenv.hostPlatform.config};
+        features = features.${pkgs.rustBuilder.rustLib.realHostTriple buildPackages.stdenv.hostPlatform};
       };
     };
   })

--- a/default.nix
+++ b/default.nix
@@ -39,7 +39,7 @@ let
   inherit (rustChannel) cargo;
   rustc = rustChannel.rust.override {
     targets = [
-      pkgs.stdenv.targetPlatform.config
+      (pkgs.rustBuilder.rustLib.realHostTriple pkgs.stdenv.targetPlatform)
     ];
   };
 

--- a/overlay/lib.nix
+++ b/overlay/lib.nix
@@ -243,4 +243,6 @@ in
   cleanLocalSource = import ./clean-local-src.nix { inherit lib; };
 
   computeFinalFeatures = import ./features.nix { inherit lib; };
+
+  realHostTriple = import ./real-host-triple.nix;
 }

--- a/overlay/make-package-set.nix
+++ b/overlay/make-package-set.nix
@@ -8,7 +8,8 @@
   cargo,
   rustc,
   mkRustCrate,
-  buildRustPackages ? null
+  buildRustPackages ? null,
+  target ? null,
 }:
 lib.fix' (self:
   let
@@ -33,7 +34,7 @@ lib.fix' (self:
     mkRustCrate_ =
       lib.makeOverridable
         (callPackage mkRustCrate {
-          inherit rustLib;
+          inherit rustLib target;
           config = rustPackageConfig;
         });
   in

--- a/overlay/real-host-triple.nix
+++ b/overlay/real-host-triple.nix
@@ -1,0 +1,24 @@
+platform:
+let
+  cpu = if platform.parsed.cpu.name == "armv6" then "arm" else platform.parsed.cpu.name;
+  vendor = platform.parsed.vendor.name;
+  kernel = platform.parsed.kernel.name;
+  abi = platform.parsed.abi.name;
+in
+if platform.isWasi then
+  "${platform.parsed.cpu.name}-wasi"
+else {
+  "i686-linux"        = "i686-unknown-linux-${abi}";
+  "x86_64-linux"      = "x86_64-unknown-linux-${abi}";
+  "armv5tel-linux"    = "arm-unknown-linux-${abi}";
+  "armv6l-linux"      = "arm-unknown-linux-${abi}";
+  "armv7a-android"    = "armv7-linux-androideabi";
+  "armv7l-linux"      = "armv7-unknown-linux-${abi}";
+  "aarch64-linux"     = "aarch64-unknown-linux-${abi}";
+  "mips64el-linux"    = "mips64el-unknown-linux-${abi}";
+  "x86_64-darwin"     = "x86_64-apple-darwin";
+  "i686-cygwin"       = "i686-pc-windows-${abi}";
+  "x86_64-cygwin"     = "x86_64-pc-windows-${abi}";
+  "x86_64-freebsd"    = "x86_64-unknown-freebsd";
+  "wasm32-emscripten" = "wasm32-unknown-emscripten";
+}.${platform.system} or platform.config

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -406,11 +406,16 @@ pub fn generate_builder(packages: Vec<PackageId>) -> Expr {
                                         proj!(
                                             features.clone().into(),
                                             Key::Expr(
-                                                proj!(
-                                                    pkgs.clone().into(),
-                                                    key!("stdenv"),
-                                                    key!("hostPlatform"),
-                                                    key!("config")
+                                                app!(
+                                                    proj!(
+                                                        pkgs.clone().into(),
+                                                        key!(rustBuilder),
+                                                        key!(rustLib),
+                                                        key!("realHostTriple")),
+                                                    proj!(
+                                                        pkgs.clone().into(),
+                                                        key!("stdenv"),
+                                                        key!("hostPlatform"))
                                                 ).into()
                                             ).into());
                                 })
@@ -438,11 +443,16 @@ pub fn generate_builder(packages: Vec<PackageId>) -> Expr {
                                                     proj!(
                                                         features.clone().into(),
                                                         Key::Expr(
-                                                            proj!(
-                                                                buildPackages.clone().into(),
-                                                                key!("stdenv"),
-                                                                key!("hostPlatform"),
-                                                                key!("config")
+                                                            app!(
+                                                                proj!(
+                                                                    pkgs.clone().into(),
+                                                                    key!(rustBuilder),
+                                                                    key!(rustLib),
+                                                                    key!("realHostTriple")),
+                                                                proj!(
+                                                                    buildPackages.clone().into(),
+                                                                    key!("stdenv"),
+                                                                    key!("hostPlatform"))
                                                             ).into()
                                                         ).into());
                                             })


### PR DESCRIPTION
I gave it a thought, and have decided to add support for arbitrary targets in order for the `rustc` to compile to targets currently unsupported by `nixpkgs`.

There are two reasons:
- Targets such as `wasm32-unknown-emscripten` has yet to land in `nixpkgs`.
- Even for targets like `x86_64-*` family, much information is not available for `cargo2nix` in order to resolve the `cfg` predicates. Examples include availability of SSE2 support in the target CPU; and new kernels/vendors not known to `nixpkgs` at this time and many others.