### PR TITLE
Fix a typo in airplane mode command inside README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ your `cargo`.
 
 To enter airplane mode, run the following command.
 ```bash
-nix-shell -A shell --fallback --substitute false
+nix-shell -A shell --fallback --option substitute false
 ```
 Then execute `vendor_source` command in the shell to install source replacement for the `crates-io`
 public crates.


### PR DESCRIPTION
I believe the diff explains itself well enough.