### PR TITLE
Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,17 @@
+# Code of Conduct
+
+## Scope
+
+This Code of Conduct applies exclusively to this repository, contributors, commentors and maintainers of this
+repository, as well as communication between them in and outside the code hosting platform.
+
+## Responsibility of Maintainers
+
+Maintainers of this repository are responsible for explaining the standards of acceptable behaviour
+in communication related to `cargo2nix`, and must execute corrective action appropriately and fairly
+in response to violation to the standards.
+They reserve the ultimate rights to editing, removal and rejection of materials in this repository,
+including but not restricted to code, pull requests, issues, wiki entries, documents and comments.
+They reserve the ultimate rights to ban, temporarily or permanently, any contributor for behaviours
+deemed inappropriate, threatening, offensive or harmful to the users and maintainers of this repository
+or violating the ethos of this Code of Conduct.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing Guidelines
+
+This documents describes rules and regulations for contributions to the project.
+The contribution process is a process of proposing and applying changes to this
+repository exclusively and does not automatically affect forks of this repository.
+
+## General contribution process
+
+This is a general contribution process for internal and external pull requests to this repository.
+
+1. Fork this repository into the personal GitHub account.
+2. Make changes on the personal fork.
+3. Make a Pull Request against this repository.
+4. Maintainers of this repository propose changes to the pull request and have the ultimate right to
+   approve the pull request.
+5. Once the pull request has been approved, maintainers of this repository have the ultimate right to
+   decide the time and process of merging or incorporating the changes.
+   In case of incorporating changes without using merges, maintainers must, in the commit messages,
+   include the authors of the pull request as co-authors.
+   In case of incorporating changes using merges, maintainers of this repository should use squashing
+   merges.
+   
+For raising issues, the GitHub issue tracker is used.
+Bug reports need to be titled with a prefix `[Bug] ` and feature requests need to be titled with a prefix
+`[Feature] `.
+The maintainers of this repository have the ultimate right to manage the issues, including tags, communication
+and moderation, (re)opening and closing.

--- a/overlay/make-shell.nix
+++ b/overlay/make-shell.nix
@@ -14,6 +14,8 @@ in
   registryMapping ? default-registry-maps,
   environment ? {},
   features ? {},
+  buildInputs ? [],
+  nativeBuildInputs ? [],
 
   lib,
   stdenv,
@@ -156,7 +158,8 @@ let
         registries);
 in
 pkgs.mkShell (environment // {
-  nativeBuildInputs = [ cargo rustc ];
+  inherit buildInputs;
+  nativeBuildInputs = [ cargo rustc ] ++ nativeBuildInputs;
 
   inherit replacementManifest;
   passAsFile = [ "replacementManifest" ];


### PR DESCRIPTION
On the side note, having ways to inject build inputs to the development shell is handy and allows users to include additional development tools and compilers.