### PR TITLE
Generate test suite manifest

### DIFF
--- a/overlay/make-shell.nix
+++ b/overlay/make-shell.nix
@@ -16,6 +16,7 @@ in
   features ? {},
   buildInputs ? [],
   nativeBuildInputs ? [],
+  shellHook ? "",
 
   lib,
   stdenv,
@@ -182,5 +183,6 @@ pkgs.mkShell (environment // {
       touch .cargo/config
       cat $replacementManifestPath >>.cargo/config
     }
+    ${shellHook}
   '';
 })


### PR DESCRIPTION
Since test suite name generated by `cargo build --tests` is not very predictable, it would be more convenient to have a list of test suite executables stored alongside them.