### PR TITLE
Propagate profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "cargo2nix"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cargo 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -1,7 +1,3 @@
-let
-  profilesByName = {
-  };
-in
 {
   release ? true,
   rootFeatures ? [
@@ -16,6 +12,8 @@ in
 }:
 let
   inherit (rustLib) fetchCratesIo fetchCrateLocal fetchCrateGit expandFeatures decideProfile genDrvsByProfile;
+  profilesByName = {
+  };
   rootFeatures' = expandFeatures rootFeatures;
   overridableMkRustCrate = f:
     let

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -1,3 +1,7 @@
+let
+  profilesByName = {
+  };
+in
 {
   release ? true,
   rootFeatures ? [
@@ -5,18 +9,23 @@
   ],
   rustPackages,
   buildRustPackages,
-  mkRustCrate,
   hostPlatform,
+  mkRustCrate,
   rustLib,
   lib,
 }:
 let
-  inherit (rustLib) fetchCratesIo fetchCrateLocal fetchCrateGit expandFeatures;
+  inherit (rustLib) fetchCratesIo fetchCrateLocal fetchCrateGit expandFeatures decideProfile genDrvsByProfile;
   rootFeatures' = expandFeatures rootFeatures;
+  overridableMkRustCrate = f:
+    let
+      drvs = genDrvsByProfile profilesByName (attrs: mkRustCrate (f attrs));
+    in { compileMode ? null, profileName ? decideProfile compileMode release }:
+      let drv = drvs.${profileName}; in if compileMode == null then drv else drv.override { inherit compileMode; };
 in
 {
-  "registry+https://github.com/rust-lang/crates.io-index".adler32."1.0.4" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".adler32."1.0.4" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "adler32";
     version = "1.0.4";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -33,10 +42,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".aho-corasick."0.7.6" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".aho-corasick."0.7.6" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "aho-corasick";
     version = "0.7.6";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -50,16 +59,16 @@ in
       [ "std" ]
     ];
     dependencies = {
-      memchr = rustPackages."registry+https://github.com/rust-lang/crates.io-index".memchr."2.2.1";
+      memchr = rustPackages."registry+https://github.com/rust-lang/crates.io-index".memchr."2.2.1" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".ansi_term."0.11.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".ansi_term."0.11.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "ansi_term";
     version = "0.11.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -71,16 +80,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      ${ if hostPlatform.parsed.kernel.name == "windows" then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8";
+      ${ if hostPlatform.parsed.kernel.name == "windows" then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".atty."0.2.13" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".atty."0.2.13" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "atty";
     version = "0.2.13";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -92,17 +101,17 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      ${ if hostPlatform.isUnix then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
-      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8";
+      ${ if hostPlatform.isUnix then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
+      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".autocfg."0.1.7" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".autocfg."0.1.7" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "autocfg";
     version = "0.1.7";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -119,10 +128,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".backtrace."0.3.40" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".backtrace."0.3.40" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "backtrace";
     version = "0.3.40";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -141,19 +150,19 @@ in
       [ "std" ]
     ];
     dependencies = {
-      backtrace_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".backtrace-sys."0.1.32";
-      cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10";
-      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
-      rustc_demangle = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rustc-demangle."0.1.16";
+      backtrace_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".backtrace-sys."0.1.32" { inherit profileName; };
+      cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10" { inherit profileName; };
+      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
+      rustc_demangle = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rustc-demangle."0.1.16" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".backtrace-sys."0.1.32" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".backtrace-sys."0.1.32" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "backtrace-sys";
     version = "0.1.32";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -165,17 +174,17 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
+      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
-      cc = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.46";
+      cc = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.46" { profileName = "__noProfile"; };
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".bitflags."1.2.1" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".bitflags."1.2.1" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "bitflags";
     version = "1.2.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -193,10 +202,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".bstr."0.2.8" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".bstr."0.2.8" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "bstr";
     version = "0.2.8";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -209,16 +218,16 @@ in
       [ "std" ]
     ];
     dependencies = {
-      memchr = rustPackages."registry+https://github.com/rust-lang/crates.io-index".memchr."2.2.1";
+      memchr = rustPackages."registry+https://github.com/rust-lang/crates.io-index".memchr."2.2.1" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".byteorder."1.3.2" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".byteorder."1.3.2" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "byteorder";
     version = "1.3.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -237,10 +246,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".bytes."0.4.12" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".bytes."0.4.12" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "bytes";
     version = "0.4.12";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -252,17 +261,17 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      byteorder = rustPackages."registry+https://github.com/rust-lang/crates.io-index".byteorder."1.3.2";
-      iovec = rustPackages."registry+https://github.com/rust-lang/crates.io-index".iovec."0.1.4";
+      byteorder = rustPackages."registry+https://github.com/rust-lang/crates.io-index".byteorder."1.3.2" { inherit profileName; };
+      iovec = rustPackages."registry+https://github.com/rust-lang/crates.io-index".iovec."0.1.4" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".bytesize."1.0.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".bytesize."1.0.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "bytesize";
     version = "1.0.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -279,10 +288,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".c2-chacha."0.2.3" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".c2-chacha."0.2.3" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "c2-chacha";
     version = "0.2.3";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -296,16 +305,16 @@ in
       [ "std" ]
     ];
     dependencies = {
-      ppv_lite86 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".ppv-lite86."0.2.6";
+      ppv_lite86 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".ppv-lite86."0.2.6" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".cargo."0.39.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".cargo."0.39.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "cargo";
     version = "0.39.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -317,89 +326,89 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      atty = rustPackages."registry+https://github.com/rust-lang/crates.io-index".atty."0.2.13";
-      byteorder = rustPackages."registry+https://github.com/rust-lang/crates.io-index".byteorder."1.3.2";
-      bytesize = rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytesize."1.0.0";
-      clap = rustPackages."registry+https://github.com/rust-lang/crates.io-index".clap."2.33.0";
-      ${ if hostPlatform.parsed.kernel.name == "darwin" then "core_foundation" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".core-foundation."0.6.4";
-      crates_io = rustPackages."registry+https://github.com/rust-lang/crates.io-index".crates-io."0.27.0";
-      crossbeam_utils = rustPackages."registry+https://github.com/rust-lang/crates.io-index".crossbeam-utils."0.6.6";
-      crypto_hash = rustPackages."registry+https://github.com/rust-lang/crates.io-index".crypto-hash."0.3.4";
-      curl = rustPackages."registry+https://github.com/rust-lang/crates.io-index".curl."0.4.25";
-      curl_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".curl-sys."0.4.23";
-      env_logger = rustPackages."registry+https://github.com/rust-lang/crates.io-index".env_logger."0.6.2";
-      failure = rustPackages."registry+https://github.com/rust-lang/crates.io-index".failure."0.1.6";
-      filetime = rustPackages."registry+https://github.com/rust-lang/crates.io-index".filetime."0.2.7";
-      flate2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".flate2."1.0.12";
-      fs2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".fs2."0.4.3";
-      ${ if hostPlatform.isWindows then "fwdansi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".fwdansi."1.0.1";
-      git2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".git2."0.9.2";
-      git2_curl = rustPackages."registry+https://github.com/rust-lang/crates.io-index".git2-curl."0.10.1";
-      glob = rustPackages."registry+https://github.com/rust-lang/crates.io-index".glob."0.3.0";
-      hex = rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.3.2";
-      home = rustPackages."registry+https://github.com/rust-lang/crates.io-index".home."0.3.4";
-      ignore = rustPackages."registry+https://github.com/rust-lang/crates.io-index".ignore."0.4.10";
-      im_rc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".im-rc."13.0.0";
-      jobserver = rustPackages."registry+https://github.com/rust-lang/crates.io-index".jobserver."0.1.17";
-      lazy_static = rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0";
-      lazycell = rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazycell."1.2.1";
-      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
-      libgit2_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libgit2-sys."0.8.2";
-      log = rustPackages."registry+https://github.com/rust-lang/crates.io-index".log."0.4.8";
-      memchr = rustPackages."registry+https://github.com/rust-lang/crates.io-index".memchr."2.2.1";
-      ${ if hostPlatform.isWindows then "miow" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".miow."0.3.3";
-      num_cpus = rustPackages."registry+https://github.com/rust-lang/crates.io-index".num_cpus."1.10.1";
-      opener = rustPackages."registry+https://github.com/rust-lang/crates.io-index".opener."0.4.1";
-      rustc_workspace_hack = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rustc-workspace-hack."1.0.0";
-      rustfix = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rustfix."0.4.6";
-      same_file = rustPackages."registry+https://github.com/rust-lang/crates.io-index".same-file."1.0.5";
-      semver = rustPackages."registry+https://github.com/rust-lang/crates.io-index".semver."0.9.0";
-      serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.101";
-      serde_ignored = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_ignored."0.0.4";
-      serde_json = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.41";
-      shell_escape = rustPackages."registry+https://github.com/rust-lang/crates.io-index".shell-escape."0.1.4";
-      strip_ansi_escapes = rustPackages."registry+https://github.com/rust-lang/crates.io-index".strip-ansi-escapes."0.1.0";
-      tar = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tar."0.4.26";
-      tempfile = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tempfile."3.1.0";
-      termcolor = rustPackages."registry+https://github.com/rust-lang/crates.io-index".termcolor."1.0.5";
-      toml = rustPackages."registry+https://github.com/rust-lang/crates.io-index".toml."0.5.3";
-      unicode_width = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-width."0.1.6";
-      url = rustPackages."registry+https://github.com/rust-lang/crates.io-index".url."1.7.2";
-      url_serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".url_serde."0.2.0";
-      walkdir = rustPackages."registry+https://github.com/rust-lang/crates.io-index".walkdir."2.2.9";
-      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8";
+      atty = rustPackages."registry+https://github.com/rust-lang/crates.io-index".atty."0.2.13" { inherit profileName; };
+      byteorder = rustPackages."registry+https://github.com/rust-lang/crates.io-index".byteorder."1.3.2" { inherit profileName; };
+      bytesize = rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytesize."1.0.0" { inherit profileName; };
+      clap = rustPackages."registry+https://github.com/rust-lang/crates.io-index".clap."2.33.0" { inherit profileName; };
+      ${ if hostPlatform.parsed.kernel.name == "darwin" then "core_foundation" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".core-foundation."0.6.4" { inherit profileName; };
+      crates_io = rustPackages."registry+https://github.com/rust-lang/crates.io-index".crates-io."0.27.0" { inherit profileName; };
+      crossbeam_utils = rustPackages."registry+https://github.com/rust-lang/crates.io-index".crossbeam-utils."0.6.6" { inherit profileName; };
+      crypto_hash = rustPackages."registry+https://github.com/rust-lang/crates.io-index".crypto-hash."0.3.4" { inherit profileName; };
+      curl = rustPackages."registry+https://github.com/rust-lang/crates.io-index".curl."0.4.25" { inherit profileName; };
+      curl_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".curl-sys."0.4.23" { inherit profileName; };
+      env_logger = rustPackages."registry+https://github.com/rust-lang/crates.io-index".env_logger."0.6.2" { inherit profileName; };
+      failure = rustPackages."registry+https://github.com/rust-lang/crates.io-index".failure."0.1.6" { inherit profileName; };
+      filetime = rustPackages."registry+https://github.com/rust-lang/crates.io-index".filetime."0.2.7" { inherit profileName; };
+      flate2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".flate2."1.0.12" { inherit profileName; };
+      fs2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".fs2."0.4.3" { inherit profileName; };
+      ${ if hostPlatform.isWindows then "fwdansi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".fwdansi."1.0.1" { inherit profileName; };
+      git2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".git2."0.9.2" { inherit profileName; };
+      git2_curl = rustPackages."registry+https://github.com/rust-lang/crates.io-index".git2-curl."0.10.1" { inherit profileName; };
+      glob = rustPackages."registry+https://github.com/rust-lang/crates.io-index".glob."0.3.0" { inherit profileName; };
+      hex = rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.3.2" { inherit profileName; };
+      home = rustPackages."registry+https://github.com/rust-lang/crates.io-index".home."0.3.4" { inherit profileName; };
+      ignore = rustPackages."registry+https://github.com/rust-lang/crates.io-index".ignore."0.4.10" { inherit profileName; };
+      im_rc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".im-rc."13.0.0" { inherit profileName; };
+      jobserver = rustPackages."registry+https://github.com/rust-lang/crates.io-index".jobserver."0.1.17" { inherit profileName; };
+      lazy_static = rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; };
+      lazycell = rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazycell."1.2.1" { inherit profileName; };
+      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
+      libgit2_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libgit2-sys."0.8.2" { inherit profileName; };
+      log = rustPackages."registry+https://github.com/rust-lang/crates.io-index".log."0.4.8" { inherit profileName; };
+      memchr = rustPackages."registry+https://github.com/rust-lang/crates.io-index".memchr."2.2.1" { inherit profileName; };
+      ${ if hostPlatform.isWindows then "miow" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".miow."0.3.3" { inherit profileName; };
+      num_cpus = rustPackages."registry+https://github.com/rust-lang/crates.io-index".num_cpus."1.10.1" { inherit profileName; };
+      opener = rustPackages."registry+https://github.com/rust-lang/crates.io-index".opener."0.4.1" { inherit profileName; };
+      rustc_workspace_hack = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rustc-workspace-hack."1.0.0" { inherit profileName; };
+      rustfix = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rustfix."0.4.6" { inherit profileName; };
+      same_file = rustPackages."registry+https://github.com/rust-lang/crates.io-index".same-file."1.0.5" { inherit profileName; };
+      semver = rustPackages."registry+https://github.com/rust-lang/crates.io-index".semver."0.9.0" { inherit profileName; };
+      serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.101" { inherit profileName; };
+      serde_ignored = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_ignored."0.0.4" { inherit profileName; };
+      serde_json = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.41" { inherit profileName; };
+      shell_escape = rustPackages."registry+https://github.com/rust-lang/crates.io-index".shell-escape."0.1.4" { inherit profileName; };
+      strip_ansi_escapes = rustPackages."registry+https://github.com/rust-lang/crates.io-index".strip-ansi-escapes."0.1.0" { inherit profileName; };
+      tar = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tar."0.4.26" { inherit profileName; };
+      tempfile = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tempfile."3.1.0" { inherit profileName; };
+      termcolor = rustPackages."registry+https://github.com/rust-lang/crates.io-index".termcolor."1.0.5" { inherit profileName; };
+      toml = rustPackages."registry+https://github.com/rust-lang/crates.io-index".toml."0.5.3" { inherit profileName; };
+      unicode_width = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-width."0.1.6" { inherit profileName; };
+      url = rustPackages."registry+https://github.com/rust-lang/crates.io-index".url."1.7.2" { inherit profileName; };
+      url_serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".url_serde."0.2.0" { inherit profileName; };
+      walkdir = rustPackages."registry+https://github.com/rust-lang/crates.io-index".walkdir."2.2.9" { inherit profileName; };
+      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "unknown".cargo2nix."0.4.0" = mkRustCrate {
-    inherit release;
+  "unknown".cargo2nix."0.5.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "cargo2nix";
-    version = "0.4.0";
+    version = "0.5.0";
     registry = "unknown";
     src = fetchCrateLocal ./.;
     features = builtins.concatLists [
     ];
     dependencies = {
-      cargo = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cargo."0.39.0";
-      once_cell = rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.2.0";
-      pathdiff = rustPackages."registry+https://github.com/rust-lang/crates.io-index".pathdiff."0.1.0";
-      regex = rustPackages."registry+https://github.com/rust-lang/crates.io-index".regex."1.3.1";
-      serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.101";
-      serde_json = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.41";
-      toml = rustPackages."registry+https://github.com/rust-lang/crates.io-index".toml."0.5.3";
+      cargo = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cargo."0.39.0" { inherit profileName; };
+      once_cell = rustPackages."registry+https://github.com/rust-lang/crates.io-index".once_cell."1.2.0" { inherit profileName; };
+      pathdiff = rustPackages."registry+https://github.com/rust-lang/crates.io-index".pathdiff."0.1.0" { inherit profileName; };
+      regex = rustPackages."registry+https://github.com/rust-lang/crates.io-index".regex."1.3.1" { inherit profileName; };
+      serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.101" { inherit profileName; };
+      serde_json = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.41" { inherit profileName; };
+      toml = rustPackages."registry+https://github.com/rust-lang/crates.io-index".toml."0.5.3" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".cc."1.0.46" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".cc."1.0.46" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "cc";
     version = "1.0.46";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -416,10 +425,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "cfg-if";
     version = "0.1.10";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -436,10 +445,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".clap."2.33.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".clap."2.33.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "clap";
     version = "2.33.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -458,22 +467,22 @@ in
       [ "vec_map" ]
     ];
     dependencies = {
-      ${ if !hostPlatform.isWindows then "ansi_term" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".ansi_term."0.11.0";
-      atty = rustPackages."registry+https://github.com/rust-lang/crates.io-index".atty."0.2.13";
-      bitflags = rustPackages."registry+https://github.com/rust-lang/crates.io-index".bitflags."1.2.1";
-      strsim = rustPackages."registry+https://github.com/rust-lang/crates.io-index".strsim."0.8.0";
-      textwrap = rustPackages."registry+https://github.com/rust-lang/crates.io-index".textwrap."0.11.0";
-      unicode_width = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-width."0.1.6";
-      vec_map = rustPackages."registry+https://github.com/rust-lang/crates.io-index".vec_map."0.8.1";
+      ${ if !hostPlatform.isWindows then "ansi_term" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".ansi_term."0.11.0" { inherit profileName; };
+      atty = rustPackages."registry+https://github.com/rust-lang/crates.io-index".atty."0.2.13" { inherit profileName; };
+      bitflags = rustPackages."registry+https://github.com/rust-lang/crates.io-index".bitflags."1.2.1" { inherit profileName; };
+      strsim = rustPackages."registry+https://github.com/rust-lang/crates.io-index".strsim."0.8.0" { inherit profileName; };
+      textwrap = rustPackages."registry+https://github.com/rust-lang/crates.io-index".textwrap."0.11.0" { inherit profileName; };
+      unicode_width = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-width."0.1.6" { inherit profileName; };
+      vec_map = rustPackages."registry+https://github.com/rust-lang/crates.io-index".vec_map."0.8.1" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".commoncrypto."0.2.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".commoncrypto."0.2.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "commoncrypto";
     version = "0.2.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -485,16 +494,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      commoncrypto_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".commoncrypto-sys."0.2.0";
+      commoncrypto_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".commoncrypto-sys."0.2.0" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".commoncrypto-sys."0.2.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".commoncrypto-sys."0.2.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "commoncrypto-sys";
     version = "0.2.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -506,16 +515,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
+      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".core-foundation."0.6.4" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".core-foundation."0.6.4" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "core-foundation";
     version = "0.6.4";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -528,17 +537,17 @@ in
       [ "mac_os_10_7_support" ]
     ];
     dependencies = {
-      core_foundation_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".core-foundation-sys."0.6.2";
-      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
+      core_foundation_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".core-foundation-sys."0.6.2" { inherit profileName; };
+      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".core-foundation-sys."0.6.2" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".core-foundation-sys."0.6.2" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "core-foundation-sys";
     version = "0.6.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -556,10 +565,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".crates-io."0.27.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".crates-io."0.27.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "crates-io";
     version = "0.27.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -571,22 +580,22 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      curl = rustPackages."registry+https://github.com/rust-lang/crates.io-index".curl."0.4.25";
-      failure = rustPackages."registry+https://github.com/rust-lang/crates.io-index".failure."0.1.6";
-      http = rustPackages."registry+https://github.com/rust-lang/crates.io-index".http."0.1.19";
-      serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.101";
-      serde_derive = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_derive."1.0.101";
-      serde_json = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.41";
-      url = rustPackages."registry+https://github.com/rust-lang/crates.io-index".url."1.7.2";
+      curl = rustPackages."registry+https://github.com/rust-lang/crates.io-index".curl."0.4.25" { inherit profileName; };
+      failure = rustPackages."registry+https://github.com/rust-lang/crates.io-index".failure."0.1.6" { inherit profileName; };
+      http = rustPackages."registry+https://github.com/rust-lang/crates.io-index".http."0.1.19" { inherit profileName; };
+      serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.101" { inherit profileName; };
+      serde_derive = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_derive."1.0.101" { profileName = "__noProfile"; };
+      serde_json = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.41" { inherit profileName; };
+      url = rustPackages."registry+https://github.com/rust-lang/crates.io-index".url."1.7.2" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".crc32fast."1.2.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".crc32fast."1.2.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "crc32fast";
     version = "1.2.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -600,16 +609,16 @@ in
       [ "std" ]
     ];
     dependencies = {
-      cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10";
+      cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".crossbeam-channel."0.3.9" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".crossbeam-channel."0.3.9" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "crossbeam-channel";
     version = "0.3.9";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -621,16 +630,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      crossbeam_utils = rustPackages."registry+https://github.com/rust-lang/crates.io-index".crossbeam-utils."0.6.6";
+      crossbeam_utils = rustPackages."registry+https://github.com/rust-lang/crates.io-index".crossbeam-utils."0.6.6" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".crossbeam-utils."0.6.6" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".crossbeam-utils."0.6.6" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "crossbeam-utils";
     version = "0.6.6";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -645,17 +654,17 @@ in
       [ "std" ]
     ];
     dependencies = {
-      cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10";
-      lazy_static = rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0";
+      cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10" { inherit profileName; };
+      lazy_static = rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".crypto-hash."0.3.4" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".crypto-hash."0.3.4" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "crypto-hash";
     version = "0.3.4";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -667,19 +676,19 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      ${ if hostPlatform.parsed.kernel.name == "darwin" || hostPlatform.parsed.kernel.name == "ios" then "commoncrypto" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".commoncrypto."0.2.0";
-      hex = rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.3.2";
-      ${ if !(hostPlatform.parsed.kernel.name == "windows" || hostPlatform.parsed.kernel.name == "darwin" || hostPlatform.parsed.kernel.name == "ios") then "openssl" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".openssl."0.10.25";
-      ${ if hostPlatform.parsed.kernel.name == "windows" then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8";
+      ${ if hostPlatform.parsed.kernel.name == "darwin" || hostPlatform.parsed.kernel.name == "ios" then "commoncrypto" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".commoncrypto."0.2.0" { inherit profileName; };
+      hex = rustPackages."registry+https://github.com/rust-lang/crates.io-index".hex."0.3.2" { inherit profileName; };
+      ${ if !(hostPlatform.parsed.kernel.name == "windows" || hostPlatform.parsed.kernel.name == "darwin" || hostPlatform.parsed.kernel.name == "ios") then "openssl" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".openssl."0.10.25" { inherit profileName; };
+      ${ if hostPlatform.parsed.kernel.name == "windows" then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".curl."0.4.25" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".curl."0.4.25" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "curl";
     version = "0.4.25";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -696,22 +705,22 @@ in
       [ "ssl" ]
     ];
     dependencies = {
-      curl_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".curl-sys."0.4.23";
-      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
-      ${ if hostPlatform.isUnix && !(hostPlatform.parsed.kernel.name == "darwin") then "openssl_probe" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".openssl-probe."0.1.2";
-      ${ if hostPlatform.isUnix && !(hostPlatform.parsed.kernel.name == "darwin") then "openssl_sys" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".openssl-sys."0.9.52";
-      ${ if hostPlatform.parsed.abi.name == "msvc" then "schannel" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".schannel."0.1.16";
-      socket2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".socket2."0.3.11";
-      ${ if hostPlatform.parsed.abi.name == "msvc" then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8";
+      curl_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".curl-sys."0.4.23" { inherit profileName; };
+      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
+      ${ if hostPlatform.isUnix && !(hostPlatform.parsed.kernel.name == "darwin") then "openssl_probe" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".openssl-probe."0.1.2" { inherit profileName; };
+      ${ if hostPlatform.isUnix && !(hostPlatform.parsed.kernel.name == "darwin") then "openssl_sys" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".openssl-sys."0.9.52" { inherit profileName; };
+      ${ if hostPlatform.parsed.abi.name == "msvc" then "schannel" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".schannel."0.1.16" { inherit profileName; };
+      socket2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".socket2."0.3.11" { inherit profileName; };
+      ${ if hostPlatform.parsed.abi.name == "msvc" then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".curl-sys."0.4.23" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".curl-sys."0.4.23" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "curl-sys";
     version = "0.4.23";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -728,23 +737,23 @@ in
       [ "ssl" ]
     ];
     dependencies = {
-      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
-      libnghttp2_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libnghttp2-sys."0.1.2";
-      libz_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libz-sys."1.0.25";
-      ${ if hostPlatform.isUnix && !(hostPlatform.parsed.kernel.name == "darwin") || hostPlatform.isUnix && !(hostPlatform.parsed.kernel.name == "darwin") then "openssl_sys" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".openssl-sys."0.9.52";
-      ${ if hostPlatform.isWindows || hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8";
+      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
+      libnghttp2_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libnghttp2-sys."0.1.2" { inherit profileName; };
+      libz_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libz-sys."1.0.25" { inherit profileName; };
+      ${ if hostPlatform.isUnix && !(hostPlatform.parsed.kernel.name == "darwin") || hostPlatform.isUnix && !(hostPlatform.parsed.kernel.name == "darwin") then "openssl_sys" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".openssl-sys."0.9.52" { inherit profileName; };
+      ${ if hostPlatform.isWindows || hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
-      cc = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.46";
-      pkg_config = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".pkg-config."0.3.16";
-      ${ if hostPlatform.parsed.abi.name == "msvc" || hostPlatform.parsed.abi.name == "msvc" then "vcpkg" else null } = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".vcpkg."0.2.7";
+      cc = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.46" { profileName = "__noProfile"; };
+      pkg_config = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".pkg-config."0.3.16" { profileName = "__noProfile"; };
+      ${ if hostPlatform.parsed.abi.name == "msvc" || hostPlatform.parsed.abi.name == "msvc" then "vcpkg" else null } = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".vcpkg."0.2.7" { profileName = "__noProfile"; };
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".env_logger."0.6.2" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".env_logger."0.6.2" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "env_logger";
     version = "0.6.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -761,20 +770,20 @@ in
       [ "termcolor" ]
     ];
     dependencies = {
-      atty = rustPackages."registry+https://github.com/rust-lang/crates.io-index".atty."0.2.13";
-      humantime = rustPackages."registry+https://github.com/rust-lang/crates.io-index".humantime."1.3.0";
-      log = rustPackages."registry+https://github.com/rust-lang/crates.io-index".log."0.4.8";
-      regex = rustPackages."registry+https://github.com/rust-lang/crates.io-index".regex."1.3.1";
-      termcolor = rustPackages."registry+https://github.com/rust-lang/crates.io-index".termcolor."1.0.5";
+      atty = rustPackages."registry+https://github.com/rust-lang/crates.io-index".atty."0.2.13" { inherit profileName; };
+      humantime = rustPackages."registry+https://github.com/rust-lang/crates.io-index".humantime."1.3.0" { inherit profileName; };
+      log = rustPackages."registry+https://github.com/rust-lang/crates.io-index".log."0.4.8" { inherit profileName; };
+      regex = rustPackages."registry+https://github.com/rust-lang/crates.io-index".regex."1.3.1" { inherit profileName; };
+      termcolor = rustPackages."registry+https://github.com/rust-lang/crates.io-index".termcolor."1.0.5" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".failure."0.1.6" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".failure."0.1.6" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "failure";
     version = "0.1.6";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -791,17 +800,17 @@ in
       [ "std" ]
     ];
     dependencies = {
-      backtrace = rustPackages."registry+https://github.com/rust-lang/crates.io-index".backtrace."0.3.40";
-      failure_derive = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".failure_derive."0.1.6";
+      backtrace = rustPackages."registry+https://github.com/rust-lang/crates.io-index".backtrace."0.3.40" { inherit profileName; };
+      failure_derive = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".failure_derive."0.1.6" { profileName = "__noProfile"; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".failure_derive."0.1.6" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".failure_derive."0.1.6" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "failure_derive";
     version = "0.1.6";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -813,19 +822,19 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      proc_macro2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.5";
-      quote = rustPackages."registry+https://github.com/rust-lang/crates.io-index".quote."1.0.2";
-      syn = rustPackages."registry+https://github.com/rust-lang/crates.io-index".syn."1.0.5";
-      synstructure = rustPackages."registry+https://github.com/rust-lang/crates.io-index".synstructure."0.12.1";
+      proc_macro2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.5" { inherit profileName; };
+      quote = rustPackages."registry+https://github.com/rust-lang/crates.io-index".quote."1.0.2" { inherit profileName; };
+      syn = rustPackages."registry+https://github.com/rust-lang/crates.io-index".syn."1.0.5" { inherit profileName; };
+      synstructure = rustPackages."registry+https://github.com/rust-lang/crates.io-index".synstructure."0.12.1" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".filetime."0.2.7" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".filetime."0.2.7" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "filetime";
     version = "0.2.7";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -837,19 +846,19 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10";
-      ${ if hostPlatform.isUnix then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
-      ${ if hostPlatform.parsed.kernel.name == "redox" then "syscall" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".redox_syscall."0.1.56";
-      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8";
+      cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10" { inherit profileName; };
+      ${ if hostPlatform.isUnix then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
+      ${ if hostPlatform.parsed.kernel.name == "redox" then "syscall" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".redox_syscall."0.1.56" { inherit profileName; };
+      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".flate2."1.0.12" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".flate2."1.0.12" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "flate2";
     version = "1.0.12";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -866,20 +875,20 @@ in
       [ "zlib" ]
     ];
     dependencies = {
-      cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10";
-      crc32fast = rustPackages."registry+https://github.com/rust-lang/crates.io-index".crc32fast."1.2.0";
-      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
-      libz_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libz-sys."1.0.25";
-      miniz_oxide = rustPackages."registry+https://github.com/rust-lang/crates.io-index".miniz_oxide."0.3.3";
+      cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10" { inherit profileName; };
+      crc32fast = rustPackages."registry+https://github.com/rust-lang/crates.io-index".crc32fast."1.2.0" { inherit profileName; };
+      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
+      libz_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libz-sys."1.0.25" { inherit profileName; };
+      miniz_oxide = rustPackages."registry+https://github.com/rust-lang/crates.io-index".miniz_oxide."0.3.3" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".fnv."1.0.6" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".fnv."1.0.6" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "fnv";
     version = "1.0.6";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -896,10 +905,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".foreign-types."0.3.2" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".foreign-types."0.3.2" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "foreign-types";
     version = "0.3.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -911,16 +920,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      foreign_types_shared = rustPackages."registry+https://github.com/rust-lang/crates.io-index".foreign-types-shared."0.1.1";
+      foreign_types_shared = rustPackages."registry+https://github.com/rust-lang/crates.io-index".foreign-types-shared."0.1.1" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".foreign-types-shared."0.1.1" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".foreign-types-shared."0.1.1" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "foreign-types-shared";
     version = "0.1.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -937,10 +946,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".fs2."0.4.3" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".fs2."0.4.3" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "fs2";
     version = "0.4.3";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -952,17 +961,17 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      ${ if hostPlatform.isUnix then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
-      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8";
+      ${ if hostPlatform.isUnix then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
+      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".fwdansi."1.0.1" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".fwdansi."1.0.1" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "fwdansi";
     version = "1.0.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -974,17 +983,17 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      memchr = rustPackages."registry+https://github.com/rust-lang/crates.io-index".memchr."2.2.1";
-      termcolor = rustPackages."registry+https://github.com/rust-lang/crates.io-index".termcolor."1.0.5";
+      memchr = rustPackages."registry+https://github.com/rust-lang/crates.io-index".memchr."2.2.1" { inherit profileName; };
+      termcolor = rustPackages."registry+https://github.com/rust-lang/crates.io-index".termcolor."1.0.5" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".getrandom."0.1.12" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".getrandom."0.1.12" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "getrandom";
     version = "0.1.12";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -997,18 +1006,18 @@ in
       [ "std" ]
     ];
     dependencies = {
-      cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10";
-      ${ if hostPlatform.isUnix || hostPlatform.parsed.kernel.name == "redox" || hostPlatform.isUnix || hostPlatform.parsed.kernel.name == "redox" then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
-      ${ if hostPlatform.parsed.kernel.name == "wasi" || hostPlatform.parsed.kernel.name == "wasi" then "wasi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".wasi."0.7.0";
+      cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10" { inherit profileName; };
+      ${ if hostPlatform.isUnix || hostPlatform.parsed.kernel.name == "redox" || hostPlatform.isUnix || hostPlatform.parsed.kernel.name == "redox" then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
+      ${ if hostPlatform.parsed.kernel.name == "wasi" || hostPlatform.parsed.kernel.name == "wasi" then "wasi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".wasi."0.7.0" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".git2."0.9.2" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".git2."0.9.2" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "git2";
     version = "0.9.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1026,22 +1035,22 @@ in
       [ "ssh_key_from_memory" ]
     ];
     dependencies = {
-      bitflags = rustPackages."registry+https://github.com/rust-lang/crates.io-index".bitflags."1.2.1";
-      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
-      libgit2_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libgit2-sys."0.8.2";
-      log = rustPackages."registry+https://github.com/rust-lang/crates.io-index".log."0.4.8";
-      ${ if hostPlatform.isUnix && !(hostPlatform.parsed.kernel.name == "darwin") then "openssl_probe" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".openssl-probe."0.1.2";
-      ${ if hostPlatform.isUnix && !(hostPlatform.parsed.kernel.name == "darwin") then "openssl_sys" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".openssl-sys."0.9.52";
-      url = rustPackages."registry+https://github.com/rust-lang/crates.io-index".url."2.1.0";
+      bitflags = rustPackages."registry+https://github.com/rust-lang/crates.io-index".bitflags."1.2.1" { inherit profileName; };
+      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
+      libgit2_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libgit2-sys."0.8.2" { inherit profileName; };
+      log = rustPackages."registry+https://github.com/rust-lang/crates.io-index".log."0.4.8" { inherit profileName; };
+      ${ if hostPlatform.isUnix && !(hostPlatform.parsed.kernel.name == "darwin") then "openssl_probe" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".openssl-probe."0.1.2" { inherit profileName; };
+      ${ if hostPlatform.isUnix && !(hostPlatform.parsed.kernel.name == "darwin") then "openssl_sys" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".openssl-sys."0.9.52" { inherit profileName; };
+      url = rustPackages."registry+https://github.com/rust-lang/crates.io-index".url."2.1.0" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".git2-curl."0.10.1" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".git2-curl."0.10.1" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "git2-curl";
     version = "0.10.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1053,19 +1062,19 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      curl = rustPackages."registry+https://github.com/rust-lang/crates.io-index".curl."0.4.25";
-      git2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".git2."0.9.2";
-      log = rustPackages."registry+https://github.com/rust-lang/crates.io-index".log."0.4.8";
-      url = rustPackages."registry+https://github.com/rust-lang/crates.io-index".url."2.1.0";
+      curl = rustPackages."registry+https://github.com/rust-lang/crates.io-index".curl."0.4.25" { inherit profileName; };
+      git2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".git2."0.9.2" { inherit profileName; };
+      log = rustPackages."registry+https://github.com/rust-lang/crates.io-index".log."0.4.8" { inherit profileName; };
+      url = rustPackages."registry+https://github.com/rust-lang/crates.io-index".url."2.1.0" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".glob."0.3.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".glob."0.3.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "glob";
     version = "0.3.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1082,10 +1091,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".globset."0.4.4" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".globset."0.4.4" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "globset";
     version = "0.4.4";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1097,20 +1106,20 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      aho_corasick = rustPackages."registry+https://github.com/rust-lang/crates.io-index".aho-corasick."0.7.6";
-      bstr = rustPackages."registry+https://github.com/rust-lang/crates.io-index".bstr."0.2.8";
-      fnv = rustPackages."registry+https://github.com/rust-lang/crates.io-index".fnv."1.0.6";
-      log = rustPackages."registry+https://github.com/rust-lang/crates.io-index".log."0.4.8";
-      regex = rustPackages."registry+https://github.com/rust-lang/crates.io-index".regex."1.3.1";
+      aho_corasick = rustPackages."registry+https://github.com/rust-lang/crates.io-index".aho-corasick."0.7.6" { inherit profileName; };
+      bstr = rustPackages."registry+https://github.com/rust-lang/crates.io-index".bstr."0.2.8" { inherit profileName; };
+      fnv = rustPackages."registry+https://github.com/rust-lang/crates.io-index".fnv."1.0.6" { inherit profileName; };
+      log = rustPackages."registry+https://github.com/rust-lang/crates.io-index".log."0.4.8" { inherit profileName; };
+      regex = rustPackages."registry+https://github.com/rust-lang/crates.io-index".regex."1.3.1" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".hex."0.3.2" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".hex."0.3.2" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "hex";
     version = "0.3.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1127,10 +1136,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".home."0.3.4" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".home."0.3.4" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "home";
     version = "0.3.4";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1142,17 +1151,17 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      ${ if hostPlatform.isWindows then "scopeguard" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".scopeguard."0.3.3";
-      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8";
+      ${ if hostPlatform.isWindows then "scopeguard" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".scopeguard."0.3.3" { inherit profileName; };
+      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".http."0.1.19" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".http."0.1.19" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "http";
     version = "0.1.19";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1164,18 +1173,18 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      bytes = rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."0.4.12";
-      fnv = rustPackages."registry+https://github.com/rust-lang/crates.io-index".fnv."1.0.6";
-      itoa = rustPackages."registry+https://github.com/rust-lang/crates.io-index".itoa."0.4.4";
+      bytes = rustPackages."registry+https://github.com/rust-lang/crates.io-index".bytes."0.4.12" { inherit profileName; };
+      fnv = rustPackages."registry+https://github.com/rust-lang/crates.io-index".fnv."1.0.6" { inherit profileName; };
+      itoa = rustPackages."registry+https://github.com/rust-lang/crates.io-index".itoa."0.4.4" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".humantime."1.3.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".humantime."1.3.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "humantime";
     version = "1.3.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1187,16 +1196,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      quick_error = rustPackages."registry+https://github.com/rust-lang/crates.io-index".quick-error."1.2.2";
+      quick_error = rustPackages."registry+https://github.com/rust-lang/crates.io-index".quick-error."1.2.2" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".idna."0.1.5" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".idna."0.1.5" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "idna";
     version = "0.1.5";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1208,18 +1217,18 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      matches = rustPackages."registry+https://github.com/rust-lang/crates.io-index".matches."0.1.8";
-      unicode_bidi = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-bidi."0.3.4";
-      unicode_normalization = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-normalization."0.1.8";
+      matches = rustPackages."registry+https://github.com/rust-lang/crates.io-index".matches."0.1.8" { inherit profileName; };
+      unicode_bidi = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-bidi."0.3.4" { inherit profileName; };
+      unicode_normalization = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-normalization."0.1.8" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".idna."0.2.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".idna."0.2.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "idna";
     version = "0.2.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1231,18 +1240,18 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      matches = rustPackages."registry+https://github.com/rust-lang/crates.io-index".matches."0.1.8";
-      unicode_bidi = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-bidi."0.3.4";
-      unicode_normalization = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-normalization."0.1.8";
+      matches = rustPackages."registry+https://github.com/rust-lang/crates.io-index".matches."0.1.8" { inherit profileName; };
+      unicode_bidi = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-bidi."0.3.4" { inherit profileName; };
+      unicode_normalization = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-normalization."0.1.8" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".ignore."0.4.10" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".ignore."0.4.10" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "ignore";
     version = "0.4.10";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1254,25 +1263,25 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      crossbeam_channel = rustPackages."registry+https://github.com/rust-lang/crates.io-index".crossbeam-channel."0.3.9";
-      globset = rustPackages."registry+https://github.com/rust-lang/crates.io-index".globset."0.4.4";
-      lazy_static = rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0";
-      log = rustPackages."registry+https://github.com/rust-lang/crates.io-index".log."0.4.8";
-      memchr = rustPackages."registry+https://github.com/rust-lang/crates.io-index".memchr."2.2.1";
-      regex = rustPackages."registry+https://github.com/rust-lang/crates.io-index".regex."1.3.1";
-      same_file = rustPackages."registry+https://github.com/rust-lang/crates.io-index".same-file."1.0.5";
-      thread_local = rustPackages."registry+https://github.com/rust-lang/crates.io-index".thread_local."0.3.6";
-      walkdir = rustPackages."registry+https://github.com/rust-lang/crates.io-index".walkdir."2.2.9";
-      ${ if hostPlatform.isWindows then "winapi_util" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi-util."0.1.2";
+      crossbeam_channel = rustPackages."registry+https://github.com/rust-lang/crates.io-index".crossbeam-channel."0.3.9" { inherit profileName; };
+      globset = rustPackages."registry+https://github.com/rust-lang/crates.io-index".globset."0.4.4" { inherit profileName; };
+      lazy_static = rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; };
+      log = rustPackages."registry+https://github.com/rust-lang/crates.io-index".log."0.4.8" { inherit profileName; };
+      memchr = rustPackages."registry+https://github.com/rust-lang/crates.io-index".memchr."2.2.1" { inherit profileName; };
+      regex = rustPackages."registry+https://github.com/rust-lang/crates.io-index".regex."1.3.1" { inherit profileName; };
+      same_file = rustPackages."registry+https://github.com/rust-lang/crates.io-index".same-file."1.0.5" { inherit profileName; };
+      thread_local = rustPackages."registry+https://github.com/rust-lang/crates.io-index".thread_local."0.3.6" { inherit profileName; };
+      walkdir = rustPackages."registry+https://github.com/rust-lang/crates.io-index".walkdir."2.2.9" { inherit profileName; };
+      ${ if hostPlatform.isWindows then "winapi_util" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi-util."0.1.2" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".im-rc."13.0.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".im-rc."13.0.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "im-rc";
     version = "13.0.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1284,18 +1293,18 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      sized_chunks = rustPackages."registry+https://github.com/rust-lang/crates.io-index".sized-chunks."0.3.1";
-      typenum = rustPackages."registry+https://github.com/rust-lang/crates.io-index".typenum."1.11.2";
+      sized_chunks = rustPackages."registry+https://github.com/rust-lang/crates.io-index".sized-chunks."0.3.1" { inherit profileName; };
+      typenum = rustPackages."registry+https://github.com/rust-lang/crates.io-index".typenum."1.11.2" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
-      rustc_version = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".rustc_version."0.2.3";
+      rustc_version = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".rustc_version."0.2.3" { profileName = "__noProfile"; };
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".iovec."0.1.4" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".iovec."0.1.4" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "iovec";
     version = "0.1.4";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1307,16 +1316,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      ${ if hostPlatform.isUnix then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
+      ${ if hostPlatform.isUnix then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".itoa."0.4.4" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".itoa."0.4.4" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "itoa";
     version = "0.4.4";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1335,10 +1344,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".jobserver."0.1.17" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".jobserver."0.1.17" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "jobserver";
     version = "0.1.17";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1350,18 +1359,18 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      ${ if hostPlatform.isWindows then "getrandom" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".getrandom."0.1.12";
-      ${ if hostPlatform.isUnix then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
-      log = rustPackages."registry+https://github.com/rust-lang/crates.io-index".log."0.4.8";
+      ${ if hostPlatform.isWindows then "getrandom" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".getrandom."0.1.12" { inherit profileName; };
+      ${ if hostPlatform.isUnix then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
+      log = rustPackages."registry+https://github.com/rust-lang/crates.io-index".log."0.4.8" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "lazy_static";
     version = "1.4.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1378,10 +1387,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".lazycell."1.2.1" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".lazycell."1.2.1" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "lazycell";
     version = "1.2.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1398,10 +1407,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "libc";
     version = "0.2.65";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1420,10 +1429,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".libgit2-sys."0.8.2" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".libgit2-sys."0.8.2" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "libgit2-sys";
     version = "0.8.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1440,21 +1449,21 @@ in
       [ "ssh_key_from_memory" ]
     ];
     dependencies = {
-      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
-      libssh2_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libssh2-sys."0.2.13";
-      libz_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libz-sys."1.0.25";
-      ${ if hostPlatform.isUnix then "openssl_sys" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".openssl-sys."0.9.52";
+      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
+      libssh2_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libssh2-sys."0.2.13" { inherit profileName; };
+      libz_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libz-sys."1.0.25" { inherit profileName; };
+      ${ if hostPlatform.isUnix then "openssl_sys" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".openssl-sys."0.9.52" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
-      cc = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.46";
-      pkg_config = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".pkg-config."0.3.16";
+      cc = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.46" { profileName = "__noProfile"; };
+      pkg_config = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".pkg-config."0.3.16" { profileName = "__noProfile"; };
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".libnghttp2-sys."0.1.2" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".libnghttp2-sys."0.1.2" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "libnghttp2-sys";
     version = "0.1.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1466,17 +1475,17 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
+      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
-      cc = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.46";
+      cc = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.46" { profileName = "__noProfile"; };
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".libssh2-sys."0.2.13" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".libssh2-sys."0.2.13" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "libssh2-sys";
     version = "0.2.13";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1488,21 +1497,21 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
-      libz_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libz-sys."1.0.25";
-      ${ if hostPlatform.isUnix then "openssl_sys" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".openssl-sys."0.9.52";
+      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
+      libz_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libz-sys."1.0.25" { inherit profileName; };
+      ${ if hostPlatform.isUnix then "openssl_sys" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".openssl-sys."0.9.52" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
-      cc = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.46";
-      pkg_config = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".pkg-config."0.3.16";
-      ${ if hostPlatform.parsed.abi.name == "msvc" then "vcpkg" else null } = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".vcpkg."0.2.7";
+      cc = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.46" { profileName = "__noProfile"; };
+      pkg_config = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".pkg-config."0.3.16" { profileName = "__noProfile"; };
+      ${ if hostPlatform.parsed.abi.name == "msvc" then "vcpkg" else null } = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".vcpkg."0.2.7" { profileName = "__noProfile"; };
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".libz-sys."1.0.25" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".libz-sys."1.0.25" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "libz-sys";
     version = "1.0.25";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1514,19 +1523,19 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
+      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
-      cc = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.46";
-      pkg_config = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".pkg-config."0.3.16";
-      ${ if hostPlatform.parsed.abi.name == "msvc" then "vcpkg" else null } = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".vcpkg."0.2.7";
+      cc = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.46" { profileName = "__noProfile"; };
+      pkg_config = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".pkg-config."0.3.16" { profileName = "__noProfile"; };
+      ${ if hostPlatform.parsed.abi.name == "msvc" then "vcpkg" else null } = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".vcpkg."0.2.7" { profileName = "__noProfile"; };
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".log."0.4.8" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".log."0.4.8" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "log";
     version = "0.4.8";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1539,16 +1548,16 @@ in
       [ "std" ]
     ];
     dependencies = {
-      cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10";
+      cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".matches."0.1.8" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".matches."0.1.8" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "matches";
     version = "0.1.8";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1565,10 +1574,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".memchr."2.2.1" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".memchr."2.2.1" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "memchr";
     version = "2.2.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1587,10 +1596,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".miniz_oxide."0.3.3" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".miniz_oxide."0.3.3" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "miniz_oxide";
     version = "0.3.3";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1602,16 +1611,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      adler32 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".adler32."1.0.4";
+      adler32 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".adler32."1.0.4" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".miow."0.3.3" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".miow."0.3.3" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "miow";
     version = "0.3.3";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1623,17 +1632,17 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      socket2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".socket2."0.3.11";
-      winapi = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8";
+      socket2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".socket2."0.3.11" { inherit profileName; };
+      winapi = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".num_cpus."1.10.1" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".num_cpus."1.10.1" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "num_cpus";
     version = "1.10.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1645,16 +1654,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
+      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".once_cell."1.2.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".once_cell."1.2.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "once_cell";
     version = "1.2.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1673,10 +1682,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".opener."0.4.1" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".opener."0.4.1" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "opener";
     version = "0.4.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1688,16 +1697,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8";
+      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".openssl."0.10.25" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".openssl."0.10.25" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "openssl";
     version = "0.10.25";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1709,21 +1718,21 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      bitflags = rustPackages."registry+https://github.com/rust-lang/crates.io-index".bitflags."1.2.1";
-      cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10";
-      foreign_types = rustPackages."registry+https://github.com/rust-lang/crates.io-index".foreign-types."0.3.2";
-      lazy_static = rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0";
-      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
-      openssl_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".openssl-sys."0.9.52";
+      bitflags = rustPackages."registry+https://github.com/rust-lang/crates.io-index".bitflags."1.2.1" { inherit profileName; };
+      cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10" { inherit profileName; };
+      foreign_types = rustPackages."registry+https://github.com/rust-lang/crates.io-index".foreign-types."0.3.2" { inherit profileName; };
+      lazy_static = rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; };
+      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
+      openssl_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".openssl-sys."0.9.52" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".openssl-probe."0.1.2" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".openssl-probe."0.1.2" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "openssl-probe";
     version = "0.1.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1740,10 +1749,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".openssl-sys."0.9.52" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".openssl-sys."0.9.52" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "openssl-sys";
     version = "0.9.52";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1755,20 +1764,20 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
+      libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
-      autocfg = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".autocfg."0.1.7";
-      cc = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.46";
-      pkg_config = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".pkg-config."0.3.16";
-      ${ if hostPlatform.parsed.abi.name == "msvc" then "vcpkg" else null } = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".vcpkg."0.2.7";
+      autocfg = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".autocfg."0.1.7" { profileName = "__noProfile"; };
+      cc = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.46" { profileName = "__noProfile"; };
+      pkg_config = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".pkg-config."0.3.16" { profileName = "__noProfile"; };
+      ${ if hostPlatform.parsed.abi.name == "msvc" then "vcpkg" else null } = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".vcpkg."0.2.7" { profileName = "__noProfile"; };
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".pathdiff."0.1.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".pathdiff."0.1.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "pathdiff";
     version = "0.1.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1785,10 +1794,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".percent-encoding."1.0.1" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".percent-encoding."1.0.1" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "percent-encoding";
     version = "1.0.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1805,10 +1814,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".percent-encoding."2.1.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".percent-encoding."2.1.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "percent-encoding";
     version = "2.1.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1825,10 +1834,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".pkg-config."0.3.16" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".pkg-config."0.3.16" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "pkg-config";
     version = "0.3.16";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1845,10 +1854,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".ppv-lite86."0.2.6" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".ppv-lite86."0.2.6" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "ppv-lite86";
     version = "0.2.6";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1867,10 +1876,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.5" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.5" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "proc-macro2";
     version = "1.0.5";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1884,16 +1893,16 @@ in
       [ "proc-macro" ]
     ];
     dependencies = {
-      unicode_xid = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-xid."0.2.0";
+      unicode_xid = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-xid."0.2.0" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".quick-error."1.2.2" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".quick-error."1.2.2" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "quick-error";
     version = "1.2.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1910,10 +1919,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".quote."1.0.2" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".quote."1.0.2" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "quote";
     version = "1.0.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1927,16 +1936,16 @@ in
       [ "proc-macro" ]
     ];
     dependencies = {
-      proc_macro2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.5";
+      proc_macro2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.5" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".rand."0.7.2" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".rand."0.7.2" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "rand";
     version = "0.7.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1953,20 +1962,20 @@ in
       [ "std" ]
     ];
     dependencies = {
-      getrandom_package = rustPackages."registry+https://github.com/rust-lang/crates.io-index".getrandom."0.1.12";
-      ${ if hostPlatform.isUnix then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
-      ${ if !(hostPlatform.parsed.kernel.name == "emscripten") then "rand_chacha" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rand_chacha."0.2.1";
-      rand_core = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rand_core."0.5.1";
-      ${ if hostPlatform.parsed.kernel.name == "emscripten" then "rand_hc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rand_hc."0.2.0";
+      getrandom_package = rustPackages."registry+https://github.com/rust-lang/crates.io-index".getrandom."0.1.12" { inherit profileName; };
+      ${ if hostPlatform.isUnix then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
+      ${ if !(hostPlatform.parsed.kernel.name == "emscripten") then "rand_chacha" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rand_chacha."0.2.1" { inherit profileName; };
+      rand_core = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rand_core."0.5.1" { inherit profileName; };
+      ${ if hostPlatform.parsed.kernel.name == "emscripten" then "rand_hc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rand_hc."0.2.0" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".rand_chacha."0.2.1" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".rand_chacha."0.2.1" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "rand_chacha";
     version = "0.2.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -1979,17 +1988,17 @@ in
       [ "std" ]
     ];
     dependencies = {
-      c2_chacha = rustPackages."registry+https://github.com/rust-lang/crates.io-index".c2-chacha."0.2.3";
-      rand_core = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rand_core."0.5.1";
+      c2_chacha = rustPackages."registry+https://github.com/rust-lang/crates.io-index".c2-chacha."0.2.3" { inherit profileName; };
+      rand_core = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rand_core."0.5.1" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".rand_core."0.5.1" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".rand_core."0.5.1" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "rand_core";
     version = "0.5.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2004,16 +2013,16 @@ in
       [ "std" ]
     ];
     dependencies = {
-      getrandom = rustPackages."registry+https://github.com/rust-lang/crates.io-index".getrandom."0.1.12";
+      getrandom = rustPackages."registry+https://github.com/rust-lang/crates.io-index".getrandom."0.1.12" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".rand_hc."0.2.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".rand_hc."0.2.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "rand_hc";
     version = "0.2.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2025,16 +2034,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      rand_core = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rand_core."0.5.1";
+      rand_core = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rand_core."0.5.1" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".redox_syscall."0.1.56" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".redox_syscall."0.1.56" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "redox_syscall";
     version = "0.1.56";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2051,10 +2060,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".regex."1.3.1" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".regex."1.3.1" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "regex";
     version = "1.3.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2084,19 +2093,19 @@ in
       [ "unicode-segment" ]
     ];
     dependencies = {
-      aho_corasick = rustPackages."registry+https://github.com/rust-lang/crates.io-index".aho-corasick."0.7.6";
-      memchr = rustPackages."registry+https://github.com/rust-lang/crates.io-index".memchr."2.2.1";
-      regex_syntax = rustPackages."registry+https://github.com/rust-lang/crates.io-index".regex-syntax."0.6.12";
-      thread_local = rustPackages."registry+https://github.com/rust-lang/crates.io-index".thread_local."0.3.6";
+      aho_corasick = rustPackages."registry+https://github.com/rust-lang/crates.io-index".aho-corasick."0.7.6" { inherit profileName; };
+      memchr = rustPackages."registry+https://github.com/rust-lang/crates.io-index".memchr."2.2.1" { inherit profileName; };
+      regex_syntax = rustPackages."registry+https://github.com/rust-lang/crates.io-index".regex-syntax."0.6.12" { inherit profileName; };
+      thread_local = rustPackages."registry+https://github.com/rust-lang/crates.io-index".thread_local."0.3.6" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".regex-syntax."0.6.12" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".regex-syntax."0.6.12" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "regex-syntax";
     version = "0.6.12";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2120,10 +2129,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".remove_dir_all."0.5.2" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".remove_dir_all."0.5.2" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "remove_dir_all";
     version = "0.5.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2135,16 +2144,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8";
+      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".rustc-demangle."0.1.16" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".rustc-demangle."0.1.16" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "rustc-demangle";
     version = "0.1.16";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2161,10 +2170,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".rustc-workspace-hack."1.0.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".rustc-workspace-hack."1.0.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "rustc-workspace-hack";
     version = "1.0.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2181,10 +2190,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".rustc_version."0.2.3" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".rustc_version."0.2.3" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "rustc_version";
     version = "0.2.3";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2196,16 +2205,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      semver = rustPackages."registry+https://github.com/rust-lang/crates.io-index".semver."0.9.0";
+      semver = rustPackages."registry+https://github.com/rust-lang/crates.io-index".semver."0.9.0" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".rustfix."0.4.6" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".rustfix."0.4.6" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "rustfix";
     version = "0.4.6";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2217,19 +2226,19 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      failure = rustPackages."registry+https://github.com/rust-lang/crates.io-index".failure."0.1.6";
-      log = rustPackages."registry+https://github.com/rust-lang/crates.io-index".log."0.4.8";
-      serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.101";
-      serde_json = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.41";
+      failure = rustPackages."registry+https://github.com/rust-lang/crates.io-index".failure."0.1.6" { inherit profileName; };
+      log = rustPackages."registry+https://github.com/rust-lang/crates.io-index".log."0.4.8" { inherit profileName; };
+      serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.101" { inherit profileName; };
+      serde_json = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.41" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".ryu."1.0.2" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".ryu."1.0.2" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "ryu";
     version = "1.0.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2246,10 +2255,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".same-file."1.0.5" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".same-file."1.0.5" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "same-file";
     version = "1.0.5";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2261,16 +2270,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      ${ if hostPlatform.isWindows then "winapi_util" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi-util."0.1.2";
+      ${ if hostPlatform.isWindows then "winapi_util" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi-util."0.1.2" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".schannel."0.1.16" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".schannel."0.1.16" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "schannel";
     version = "0.1.16";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2282,17 +2291,17 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      lazy_static = rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0";
-      winapi = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8";
+      lazy_static = rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; };
+      winapi = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".scopeguard."0.3.3" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".scopeguard."0.3.3" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "scopeguard";
     version = "0.3.3";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2311,10 +2320,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".semver."0.9.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".semver."0.9.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "semver";
     version = "0.9.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2328,17 +2337,17 @@ in
       [ "serde" ]
     ];
     dependencies = {
-      semver_parser = rustPackages."registry+https://github.com/rust-lang/crates.io-index".semver-parser."0.7.0";
-      serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.101";
+      semver_parser = rustPackages."registry+https://github.com/rust-lang/crates.io-index".semver-parser."0.7.0" { inherit profileName; };
+      serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.101" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".semver-parser."0.7.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".semver-parser."0.7.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "semver-parser";
     version = "0.7.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2355,10 +2364,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".serde."1.0.101" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".serde."1.0.101" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "serde";
     version = "1.0.101";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2374,16 +2383,16 @@ in
       [ "std" ]
     ];
     dependencies = {
-      serde_derive = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_derive."1.0.101";
+      serde_derive = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_derive."1.0.101" { profileName = "__noProfile"; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".serde_derive."1.0.101" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".serde_derive."1.0.101" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "serde_derive";
     version = "1.0.101";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2396,18 +2405,18 @@ in
       [ "default" ]
     ];
     dependencies = {
-      proc_macro2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.5";
-      quote = rustPackages."registry+https://github.com/rust-lang/crates.io-index".quote."1.0.2";
-      syn = rustPackages."registry+https://github.com/rust-lang/crates.io-index".syn."1.0.5";
+      proc_macro2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.5" { inherit profileName; };
+      quote = rustPackages."registry+https://github.com/rust-lang/crates.io-index".quote."1.0.2" { inherit profileName; };
+      syn = rustPackages."registry+https://github.com/rust-lang/crates.io-index".syn."1.0.5" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".serde_ignored."0.0.4" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".serde_ignored."0.0.4" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "serde_ignored";
     version = "0.0.4";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2419,16 +2428,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.101";
+      serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.101" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.41" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.41" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "serde_json";
     version = "1.0.41";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2442,18 +2451,18 @@ in
       [ "raw_value" ]
     ];
     dependencies = {
-      itoa = rustPackages."registry+https://github.com/rust-lang/crates.io-index".itoa."0.4.4";
-      ryu = rustPackages."registry+https://github.com/rust-lang/crates.io-index".ryu."1.0.2";
-      serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.101";
+      itoa = rustPackages."registry+https://github.com/rust-lang/crates.io-index".itoa."0.4.4" { inherit profileName; };
+      ryu = rustPackages."registry+https://github.com/rust-lang/crates.io-index".ryu."1.0.2" { inherit profileName; };
+      serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.101" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".shell-escape."0.1.4" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".shell-escape."0.1.4" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "shell-escape";
     version = "0.1.4";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2470,10 +2479,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".sized-chunks."0.3.1" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".sized-chunks."0.3.1" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "sized-chunks";
     version = "0.3.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2485,16 +2494,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      typenum = rustPackages."registry+https://github.com/rust-lang/crates.io-index".typenum."1.11.2";
+      typenum = rustPackages."registry+https://github.com/rust-lang/crates.io-index".typenum."1.11.2" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".smallvec."0.6.10" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".smallvec."0.6.10" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "smallvec";
     version = "0.6.10";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2513,10 +2522,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".socket2."0.3.11" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".socket2."0.3.11" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "socket2";
     version = "0.3.11";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2528,19 +2537,19 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      ${ if hostPlatform.isUnix || hostPlatform.parsed.kernel.name == "redox" then "cfg_if" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10";
-      ${ if hostPlatform.isUnix || hostPlatform.parsed.kernel.name == "redox" then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
-      ${ if hostPlatform.parsed.kernel.name == "redox" then "syscall" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".redox_syscall."0.1.56";
-      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8";
+      ${ if hostPlatform.isUnix || hostPlatform.parsed.kernel.name == "redox" then "cfg_if" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10" { inherit profileName; };
+      ${ if hostPlatform.isUnix || hostPlatform.parsed.kernel.name == "redox" then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
+      ${ if hostPlatform.parsed.kernel.name == "redox" then "syscall" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".redox_syscall."0.1.56" { inherit profileName; };
+      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".strip-ansi-escapes."0.1.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".strip-ansi-escapes."0.1.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "strip-ansi-escapes";
     version = "0.1.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2552,16 +2561,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      vte = rustPackages."registry+https://github.com/rust-lang/crates.io-index".vte."0.3.3";
+      vte = rustPackages."registry+https://github.com/rust-lang/crates.io-index".vte."0.3.3" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".strsim."0.8.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".strsim."0.8.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "strsim";
     version = "0.8.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2578,10 +2587,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".syn."1.0.5" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".syn."1.0.5" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "syn";
     version = "1.0.5";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2602,18 +2611,18 @@ in
       [ "visit" ]
     ];
     dependencies = {
-      proc_macro2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.5";
-      quote = rustPackages."registry+https://github.com/rust-lang/crates.io-index".quote."1.0.2";
-      unicode_xid = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-xid."0.2.0";
+      proc_macro2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.5" { inherit profileName; };
+      quote = rustPackages."registry+https://github.com/rust-lang/crates.io-index".quote."1.0.2" { inherit profileName; };
+      unicode_xid = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-xid."0.2.0" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".synstructure."0.12.1" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".synstructure."0.12.1" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "synstructure";
     version = "0.12.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2625,19 +2634,19 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      proc_macro2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.5";
-      quote = rustPackages."registry+https://github.com/rust-lang/crates.io-index".quote."1.0.2";
-      syn = rustPackages."registry+https://github.com/rust-lang/crates.io-index".syn."1.0.5";
-      unicode_xid = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-xid."0.2.0";
+      proc_macro2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.5" { inherit profileName; };
+      quote = rustPackages."registry+https://github.com/rust-lang/crates.io-index".quote."1.0.2" { inherit profileName; };
+      syn = rustPackages."registry+https://github.com/rust-lang/crates.io-index".syn."1.0.5" { inherit profileName; };
+      unicode_xid = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-xid."0.2.0" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".tar."0.4.26" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".tar."0.4.26" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "tar";
     version = "0.4.26";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2649,18 +2658,18 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      filetime = rustPackages."registry+https://github.com/rust-lang/crates.io-index".filetime."0.2.7";
-      ${ if hostPlatform.isUnix then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
-      ${ if hostPlatform.parsed.kernel.name == "redox" then "syscall" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".redox_syscall."0.1.56";
+      filetime = rustPackages."registry+https://github.com/rust-lang/crates.io-index".filetime."0.2.7" { inherit profileName; };
+      ${ if hostPlatform.isUnix then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
+      ${ if hostPlatform.parsed.kernel.name == "redox" then "syscall" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".redox_syscall."0.1.56" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".tempfile."3.1.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".tempfile."3.1.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "tempfile";
     version = "3.1.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2672,21 +2681,21 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10";
-      ${ if hostPlatform.isUnix then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65";
-      rand = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rand."0.7.2";
-      ${ if hostPlatform.parsed.kernel.name == "redox" then "syscall" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".redox_syscall."0.1.56";
-      remove_dir_all = rustPackages."registry+https://github.com/rust-lang/crates.io-index".remove_dir_all."0.5.2";
-      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8";
+      cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10" { inherit profileName; };
+      ${ if hostPlatform.isUnix then "libc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
+      rand = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rand."0.7.2" { inherit profileName; };
+      ${ if hostPlatform.parsed.kernel.name == "redox" then "syscall" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".redox_syscall."0.1.56" { inherit profileName; };
+      remove_dir_all = rustPackages."registry+https://github.com/rust-lang/crates.io-index".remove_dir_all."0.5.2" { inherit profileName; };
+      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".termcolor."1.0.5" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".termcolor."1.0.5" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "termcolor";
     version = "1.0.5";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2698,16 +2707,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      ${ if hostPlatform.isWindows then "wincolor" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".wincolor."1.0.2";
+      ${ if hostPlatform.isWindows then "wincolor" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".wincolor."1.0.2" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".textwrap."0.11.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".textwrap."0.11.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "textwrap";
     version = "0.11.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2719,16 +2728,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      unicode_width = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-width."0.1.6";
+      unicode_width = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-width."0.1.6" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".thread_local."0.3.6" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".thread_local."0.3.6" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "thread_local";
     version = "0.3.6";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2740,16 +2749,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      lazy_static = rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0";
+      lazy_static = rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".toml."0.5.3" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".toml."0.5.3" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "toml";
     version = "0.5.3";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2762,16 +2771,16 @@ in
       [ "default" ]
     ];
     dependencies = {
-      serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.101";
+      serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.101" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".typenum."1.11.2" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".typenum."1.11.2" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "typenum";
     version = "1.11.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2788,10 +2797,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".unicode-bidi."0.3.4" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".unicode-bidi."0.3.4" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "unicode-bidi";
     version = "0.3.4";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2804,16 +2813,16 @@ in
       [ "default" ]
     ];
     dependencies = {
-      matches = rustPackages."registry+https://github.com/rust-lang/crates.io-index".matches."0.1.8";
+      matches = rustPackages."registry+https://github.com/rust-lang/crates.io-index".matches."0.1.8" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".unicode-normalization."0.1.8" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".unicode-normalization."0.1.8" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "unicode-normalization";
     version = "0.1.8";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2825,16 +2834,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      smallvec = rustPackages."registry+https://github.com/rust-lang/crates.io-index".smallvec."0.6.10";
+      smallvec = rustPackages."registry+https://github.com/rust-lang/crates.io-index".smallvec."0.6.10" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".unicode-width."0.1.6" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".unicode-width."0.1.6" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "unicode-width";
     version = "0.1.6";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2852,10 +2861,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".unicode-xid."0.2.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".unicode-xid."0.2.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "unicode-xid";
     version = "0.2.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2873,10 +2882,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".url."1.7.2" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".url."1.7.2" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "url";
     version = "1.7.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2888,18 +2897,18 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      idna = rustPackages."registry+https://github.com/rust-lang/crates.io-index".idna."0.1.5";
-      matches = rustPackages."registry+https://github.com/rust-lang/crates.io-index".matches."0.1.8";
-      percent_encoding = rustPackages."registry+https://github.com/rust-lang/crates.io-index".percent-encoding."1.0.1";
+      idna = rustPackages."registry+https://github.com/rust-lang/crates.io-index".idna."0.1.5" { inherit profileName; };
+      matches = rustPackages."registry+https://github.com/rust-lang/crates.io-index".matches."0.1.8" { inherit profileName; };
+      percent_encoding = rustPackages."registry+https://github.com/rust-lang/crates.io-index".percent-encoding."1.0.1" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".url."2.1.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".url."2.1.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "url";
     version = "2.1.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2911,18 +2920,18 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      idna = rustPackages."registry+https://github.com/rust-lang/crates.io-index".idna."0.2.0";
-      matches = rustPackages."registry+https://github.com/rust-lang/crates.io-index".matches."0.1.8";
-      percent_encoding = rustPackages."registry+https://github.com/rust-lang/crates.io-index".percent-encoding."2.1.0";
+      idna = rustPackages."registry+https://github.com/rust-lang/crates.io-index".idna."0.2.0" { inherit profileName; };
+      matches = rustPackages."registry+https://github.com/rust-lang/crates.io-index".matches."0.1.8" { inherit profileName; };
+      percent_encoding = rustPackages."registry+https://github.com/rust-lang/crates.io-index".percent-encoding."2.1.0" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".url_serde."0.2.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".url_serde."0.2.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "url_serde";
     version = "0.2.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2934,17 +2943,17 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.101";
-      url = rustPackages."registry+https://github.com/rust-lang/crates.io-index".url."1.7.2";
+      serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.101" { inherit profileName; };
+      url = rustPackages."registry+https://github.com/rust-lang/crates.io-index".url."1.7.2" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".utf8parse."0.1.1" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".utf8parse."0.1.1" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "utf8parse";
     version = "0.1.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2961,10 +2970,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".vcpkg."0.2.7" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".vcpkg."0.2.7" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "vcpkg";
     version = "0.2.7";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -2981,10 +2990,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".vec_map."0.8.1" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".vec_map."0.8.1" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "vec_map";
     version = "0.8.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -3001,10 +3010,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".vte."0.3.3" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".vte."0.3.3" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "vte";
     version = "0.3.3";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -3016,16 +3025,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      utf8parse = rustPackages."registry+https://github.com/rust-lang/crates.io-index".utf8parse."0.1.1";
+      utf8parse = rustPackages."registry+https://github.com/rust-lang/crates.io-index".utf8parse."0.1.1" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".walkdir."2.2.9" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".walkdir."2.2.9" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "walkdir";
     version = "2.2.9";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -3037,18 +3046,18 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      same_file = rustPackages."registry+https://github.com/rust-lang/crates.io-index".same-file."1.0.5";
-      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8";
-      ${ if hostPlatform.isWindows then "winapi_util" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi-util."0.1.2";
+      same_file = rustPackages."registry+https://github.com/rust-lang/crates.io-index".same-file."1.0.5" { inherit profileName; };
+      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
+      ${ if hostPlatform.isWindows then "winapi_util" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi-util."0.1.2" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".wasi."0.7.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".wasi."0.7.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "wasi";
     version = "0.7.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -3067,10 +3076,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "winapi";
     version = "0.3.8";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -3120,17 +3129,17 @@ in
       [ "ws2tcpip" ]
     ];
     dependencies = {
-      ${ if hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" then "winapi_i686_pc_windows_gnu" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi-i686-pc-windows-gnu."0.4.0";
-      ${ if hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" then "winapi_x86_64_pc_windows_gnu" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi-x86_64-pc-windows-gnu."0.4.0";
+      ${ if hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" || hostPlatform.config == "i686-pc-windows-gnu" then "winapi_i686_pc_windows_gnu" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi-i686-pc-windows-gnu."0.4.0" { inherit profileName; };
+      ${ if hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" then "winapi_x86_64_pc_windows_gnu" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi-x86_64-pc-windows-gnu."0.4.0" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".winapi-i686-pc-windows-gnu."0.4.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".winapi-i686-pc-windows-gnu."0.4.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "winapi-i686-pc-windows-gnu";
     version = "0.4.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -3147,10 +3156,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".winapi-util."0.1.2" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".winapi-util."0.1.2" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "winapi-util";
     version = "0.1.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -3162,16 +3171,16 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8";
+      ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".winapi-x86_64-pc-windows-gnu."0.4.0" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".winapi-x86_64-pc-windows-gnu."0.4.0" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "winapi-x86_64-pc-windows-gnu";
     version = "0.4.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -3188,10 +3197,10 @@ in
     };
     buildDependencies = {
     };
-  };
+  });
   
-  "registry+https://github.com/rust-lang/crates.io-index".wincolor."1.0.2" = mkRustCrate {
-    inherit release;
+  "registry+https://github.com/rust-lang/crates.io-index".wincolor."1.0.2" = overridableMkRustCrate ({ profileName, profile }: {
+    inherit release profile;
     name = "wincolor";
     version = "1.0.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
@@ -3203,14 +3212,14 @@ in
     features = builtins.concatLists [
     ];
     dependencies = {
-      winapi = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8";
-      winapi_util = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi-util."0.1.2";
+      winapi = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
+      winapi_util = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi-util."0.1.2" { inherit profileName; };
     };
     devDependencies = {
     };
     buildDependencies = {
     };
-  };
+  });
   
 }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo2nix"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2018"
 license = "MIT"
 

--- a/default.nix
+++ b/default.nix
@@ -108,11 +108,11 @@ let
   };
 in
   # `rustPkgs` now contains all crates in the dependency graph.
-  # To build normal binaries, use `rustPkgs.<registry>.<crate>.<version>`.
+  # To build normal binaries, use `rustPkgs.<registry>.<crate>.<version> { }`.
   # To build test binaries (equivalent to `cargo build --tests`), use
-  #   `rustPkgs.<registry>.<crate>.<version>.override { compileMode = "test"; }`.
+  #   `rustPkgs.<registry>.<crate>.<version>{ compileMode = "test"; }`.
   # To build bench binaries (equivalent to `cargo build --benches`), use
-  #   `rustPkgs.<registry>.<crate>.<version>.override { compileMode = "bench"; }`.
+  #   `rustPkgs.<registry>.<crate>.<version>{ compileMode = "bench"; }`.
 {
-  package = rustPkgs."unknown".cargo2nix."0.4.0";
+  package = rustPkgs."unknown".cargo2nix."0.5.0" { };
 }

--- a/overlay/lib/default.nix
+++ b/overlay/lib/default.nix
@@ -3,6 +3,7 @@
   inherit (callPackage ./features.nix { }) expandFeatures;
   inherit (callPackage ./splice.nix { }) splicePackages;
   inherit (callPackage ./fetch.nix { }) fetchCrateLocal fetchCrateGit fetchCratesIo;
+  inherit (callPackage ./profiles.nix { }) decideProfile genDrvsByProfile;
 
   json2toml = pkgs.buildPackages.buildPackages.callPackage ./json2toml.nix { };
   toml2json = pkgs.buildPackages.buildPackages.callPackage ./toml2json.nix { };

--- a/overlay/lib/profiles.nix
+++ b/overlay/lib/profiles.nix
@@ -1,0 +1,37 @@
+let
+  profileNames = [
+    "release"
+    "dev"
+    "test"
+    "bench"
+    "__noProfile" # A placeholder profile for build scripts, which don't respect any profiles.
+  ];
+in
+{ }:
+{
+  # Decides which profile to use based on compile mode and whether release is enabled.
+  # Ported from https://github.com/rust-lang/cargo/blob/rust-1.38.0/src/cargo/core/profiles.rs#L86.
+  decideProfile = compileMode: release:
+    if compileMode == "test" || compileMode == "bench"
+      then if release then "bench" else "test"
+    else if compileMode == "build" || compileMode == null
+      then if release then "release" else "dev"
+    else
+      throw "unknown compile mode";
+
+  # Generates a set whose keys are all available profile names (see above).
+  # Type: Map ProfileName Profile -> (ProfileName -> Profile -> a) -> Map ProfileName a
+  genDrvsByProfile = profilesByName: f:
+    let
+      nullProfileDrv = f { profileName = "__noProfile"; profile = null; };
+    in
+      builtins.listToAttrs
+        (builtins.map
+          (profileName: {
+            name = profileName;
+            value = if profilesByName ? "${profileName}"
+              then f { inherit profileName; profile = profilesByName.${profileName}; }
+              else nullProfileDrv;
+          })
+          profileNames);
+}

--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -10,7 +10,7 @@
   stdenv,
 }:
 {
-  release, # Compiling in release profile?
+  release, # Compiling in release mode?
   name,
   version,
   registry,
@@ -20,11 +20,12 @@
   devDependencies,
   buildDependencies,
   compileMode ? "build",
+  profile,
   meta ? { },
 }:
 with builtins; with lib;
 let
-  inherit (rustLib) realHostTriple;
+  inherit (rustLib) realHostTriple decideProfile;
 
   accessConfig = type: default:
     let
@@ -64,6 +65,7 @@ let
         ${ if manifest ? test then "test" else null } = manifest.test;
         ${ if manifest ? example then "example" else null } = manifest.example;
         features = genAttrs features (_: [ ]);
+        profile.${ decideProfile compileMode release } = profile;
       };
 
   wrapper = rustpkg: pkgs.writeScriptBin rustpkg ''
@@ -143,7 +145,6 @@ let
         devDependencies
         buildDependencies
         features;
-      panicStrategy = panicStrategy';
       shell = pkgs.mkShell (removeAttrs drvAttrs ["src"]);
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,10 +81,17 @@ fn main() {
         }
     }
 
+    let profiles = manifest::extract_profiles(&std::fs::read(&root_manifest_path).unwrap());
     let scope = Scope::default();
-
     let display = DisplayFn(|f: &mut fmt::Formatter| {
         let mut f = Indented::new(f);
+        writeln!(f, "let")?;
+        writeln!(
+            f.indent(2),
+            "profilesByName = {};",
+            display_profiles_nix(&profiles)
+        )?;
+        writeln!(f, "in")?;
         writeln!(f, "{{")?;
         {
             let mut f = f.indent(2);
@@ -96,8 +103,8 @@ fn main() {
             )?;
             writeln!(f, "{},", scope.crates)?;
             writeln!(f, "{},", scope.build_crates)?;
-            writeln!(f, "{},", scope.mk_rust_crate)?;
             writeln!(f, "{},", scope.host_platform)?;
+            writeln!(f, "mkRustCrate,")?;
             writeln!(f, "rustLib,")?;
             writeln!(f, "lib,")?;
         }
@@ -107,17 +114,31 @@ fn main() {
             let mut f = f.indent(2);
             writeln!(
                 f,
-                "inherit (rustLib) {} {} {} {};",
+                "inherit (rustLib) {} {} {} {} decideProfile genDrvsByProfile;",
                 scope.fetch_crate_crates_io,
                 scope.fetch_crate_local,
                 scope.fetch_crate_git,
-                scope.expand_features
+                scope.expand_features,
             )?;
             writeln!(
                 f,
                 "{} = {} rootFeatures;",
                 scope.root_features, scope.expand_features
             )?;
+            writeln!(f, "{} = f:", scope.mk_rust_crate)?;
+            {
+                let mut f = f.indent(2);
+                writeln!(f, "let")?;
+                writeln!(
+                    f.indent(2),
+                    "drvs = genDrvsByProfile profilesByName (attrs: mkRustCrate (f attrs));"
+                )?;
+                writeln!(
+                    f,
+                    "in {{ compileMode ? null, profileName ? decideProfile compileMode release }}:"
+                )?;
+                writeln!(f.indent(2), "let drv = drvs.${{profileName}}; in if compileMode == null then drv else drv.override {{ inherit compileMode; }};")?;
+            }
         }
         writeln!(f, "in")?;
         writeln!(f, "{{")?;
@@ -267,7 +288,7 @@ impl Default for Scope<'static> {
             root_features: "rootFeatures'",
             expand_features: "expandFeatures",
             release: "release",
-            mk_rust_crate: "mkRustCrate",
+            mk_rust_crate: "overridableMkRustCrate",
             fetch_crate_crates_io: "fetchCratesIo",
             fetch_crate_git: "fetchCrateGit",
             fetch_crate_local: "fetchCrateLocal",
@@ -408,13 +429,13 @@ impl<'a> ResolvedPackage<'a> {
         let mut f = Indented::new(f);
         writeln!(
             f,
-            "{} = {} {{",
+            "{} = {} ({{ profileName, profile }}: {{",
             display_pkg_id_nix(self.pkg.package_id()),
             outer.mk_rust_crate
         )?;
         {
             let mut f = f.indent(2);
-            writeln!(f, "inherit {};", outer.release)?;
+            writeln!(f, "inherit {} profile;", outer.release)?;
             writeln!(f, "name = {:?};", self.pkg.name())?;
             writeln!(f, "version = {:?};", self.pkg.version().to_string())?;
             writeln!(
@@ -451,19 +472,13 @@ impl<'a> ResolvedPackage<'a> {
                 ("buildDependencies", DependencyKind::Build),
             ] {
                 writeln!(f, "{} = {{", attr)?;
+
                 for ((dep_id, _), rdep) in self
                     .deps
                     .iter()
                     .filter(|((_, dep_kind), _)| dep_kind == kind)
                 {
                     let mut f = f.indent(2);
-                    let should_run_on_build_platform =
-                        *kind == DependencyKind::Build || is_proc_macro(rdep.pkg);
-                    let crate_set = if should_run_on_build_platform {
-                        outer.build_crates
-                    } else {
-                        outer.crates
-                    };
                     match rdep
                         .optionality
                         .to_expr(outer.root_features, n_root_pkgs)
@@ -485,13 +500,30 @@ impl<'a> ResolvedPackage<'a> {
                             rdep.extern_name,
                         )?,
                     }
-                    write!(f, " = {}.{}", crate_set, display_pkg_id_nix(dep_id.clone()),)?;
+
+                    let is_build_dep = *kind == DependencyKind::Build || is_proc_macro(rdep.pkg);
+                    let crate_set = if is_build_dep {
+                        outer.build_crates
+                    } else {
+                        outer.crates
+                    };
+                    write!(
+                        f,
+                        " = {}.{} ",
+                        crate_set,
+                        display_pkg_id_nix(dep_id.clone()),
+                    )?;
+                    if is_build_dep {
+                        write!(f, r#"{{ profileName = "__noProfile"; }}"#)?;
+                    } else {
+                        write!(f, r#"{{ inherit profileName; }}"#)?;
+                    }
                     writeln!(f, ";")?;
                 }
                 writeln!(f, "}};")?;
             }
         }
-        writeln!(f, "}};")
+        writeln!(f, "}});")
     }
 }
 
@@ -667,4 +699,21 @@ fn prefetch_git(url: &str, rev: &str) -> Result<String, Box<dyn std::error::Erro
             String::from_utf8(stderr)
         ))?
     }
+}
+
+fn display_profiles_nix(profiles: &manifest::TomlProfile) -> impl '_ + fmt::Display {
+    DisplayFn(move |f: &mut fmt::Formatter| {
+        let mut f = Indented::new(f);
+        writeln!(f, "{{")?;
+        for (name, profile) in profiles.iter() {
+            let mut f = f.indent(2);
+            writeln!(
+                f,
+                "{} = builtins.fromTOML {:?};",
+                name,
+                toml::to_string(profile).unwrap()
+            )?;
+        }
+        write!(f, "}}")
+    })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,13 +85,6 @@ fn main() {
     let scope = Scope::default();
     let display = DisplayFn(|f: &mut fmt::Formatter| {
         let mut f = Indented::new(f);
-        writeln!(f, "let")?;
-        writeln!(
-            f.indent(2),
-            "profilesByName = {};",
-            display_profiles_nix(&profiles)
-        )?;
-        writeln!(f, "in")?;
         writeln!(f, "{{")?;
         {
             let mut f = f.indent(2);
@@ -120,6 +113,7 @@ fn main() {
                 scope.fetch_crate_git,
                 scope.expand_features,
             )?;
+            writeln!(f, "profilesByName = {};", display_profiles_nix(&profiles))?;
             writeln!(
                 f,
                 "{} = {} rootFeatures;",

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,15 +1,31 @@
 use toml::value::Table;
 
 use serde::Deserialize;
+use std::collections::BTreeMap;
 
-pub fn extract_profiles(manifest_contents: &[u8]) -> Table {
+pub type TomlProfile = BTreeMap<String, Table>;
+
+pub fn extract_profiles(manifest_contents: &[u8]) -> TomlProfile {
     #[derive(Debug, Deserialize)]
     struct Manifest {
-        pub profile: Option<Table>,
+        pub profile: Option<TomlProfile>,
     }
 
     toml::from_slice::<Manifest>(manifest_contents)
         .ok()
         .and_then(|m| m.profile)
+        .map(|mut profiles_by_name| {
+            remove_panic(&mut profiles_by_name);
+            profiles_by_name
+        })
         .unwrap_or_default()
+}
+
+// Remove the `panic` key from `test` and `bench` profiles, which is ignored by `cargo`.
+fn remove_panic(profiles_by_name: &mut TomlProfile) {
+    for (name, profile) in profiles_by_name.iter_mut() {
+        if name == "test" || name == "bench" {
+            profile.remove("panic");
+        }
+    }
 }


### PR DESCRIPTION
This PR adds support for the [`[profile.*]`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-profile-sections) sections defined at the top level `Cargo.toml`. 
