### PR TITLE
Overrides

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -22,76 +22,16 @@ let
       in
        overlays ++ [ cargo2nixOverlay rustOverlay ];
   };
-  inherit (pkgs) lib buildPackages;
 
-  # 2. Configure environments for building crates.
-  # `rustPackageConfig` takes a package set and returns a set describing additional dependencies for building
-  # crates with that package set.
-  # The returned set should be of the form:
-  # {
-  #   <input> = {
-  #     <package_id> = {};
-  #     <package_id> = {};
-  #   };
-  # }
-  # where
-  # `<input>` is one of:
-  # - `environment: a set of environment variables available at build time.
-  # - `buildInputs`: similar to its `std.mkDervation` cousin.
-  # - `nativeBuildInputs`: similar to its `stdenv.mkDerivation` cousin.
-  # - `rustcflags`: a list of extra flags that are passed to `rustc` when building the crate.
-  # - `rustcBuildFlags`: a list of extra flags that are passed to `rustc` when building the crate's build script (`build.rs`).
-  #
-  # `<package_id>` follows the convention `<registry>.<crate>.<version>` as mentioned in `README`.
-  rustPackageConfig = pkgs:
-    let
-      # A quick fix for missing frameworks errors on macOS.
-      darwinFrameworks = lib.optionals pkgs.hostPlatform.isDarwin
-        (with pkgs.darwin.apple_sdk.frameworks; [ Security CoreServices ]);
-    in
-      {
-        rustcflags = {
-          "registry+https://github.com/rust-lang/crates.io-index"."*" = [ "--cap-lints" "warn" ];
-        };
-        nativeBuildInputs = {
-          "registry+https://github.com/rust-lang/crates.io-index".curl-sys."*" = darwinFrameworks;
-          "registry+https://github.com/rust-lang/crates.io-index".libgit2-sys."*" = darwinFrameworks;
-        };
-        buildInputs = {
-          "registry+https://github.com/rust-lang/crates.io-index".libgit2-sys."*" = [ pkgs.libiconv ];
-          "registry+https://github.com/rust-lang/crates.io-index".cargo."*" = [ pkgs.libiconv ] ++ darwinFrameworks;
-          unknown.cargo2nix."*" = [ pkgs.libiconv ] ++ darwinFrameworks;
-        };
-        environment = {
-          "registry+https://github.com/rust-lang/crates.io-index".openssl-sys."*" =
-            let
-              envize = s: builtins.replaceStrings ["-"] ["_"] (lib.toUpper s);
-              envBuildPlatform = envize pkgs.buildPlatform.config;
-              envHostPlatform = envize pkgs.hostPlatform.config;
-              patchOpenssl = pkgs: (pkgs.openssl.override {
-                # `perl` is only used at build time, but the derivation incorrectly uses host `perl` as an input.
-                perl = pkgs.buildPackages.buildPackages.perl;
-              }).overrideAttrs (drv: {
-                installTargets = "install_sw";
-                outputs = [ "dev" "out" "bin" ];
-              });
-              joinOpenssl = openssl: buildPackages.symlinkJoin {
-                name = "openssl"; paths = with openssl; [ out dev ];
-              };
-            in
-              # We don't use key literals here, as they might collide if `hostPlatform == buildPlatform`.
-              builtins.listToAttrs [
-                { name = "${envBuildPlatform}_OPENSSL_DIR"; value = joinOpenssl (patchOpenssl buildPackages); }
-                { name = "${envHostPlatform}_OPENSSL_DIR"; value = joinOpenssl (patchOpenssl pkgs); }
-              ];
-        };
-      };
-
-  # 3. Builds the rust package set, which contains all crates in your cargo workspace's dependency graph.
+  # 2. Builds the rust package set, which contains all crates in your cargo workspace's dependency graph.
   # `makePackageSet'` accepts the following arguments:
   # - `packageFun` (required): The generated `Cargo.nix` file, which returns the whole dependency graph.
   # - `rustChannel` (required): The Rust channel used to build the package set.
-  # - `rustPackageConfig` (optional): See above.
+  # - `packageOverrides` (optional):
+  #     A function taking a package set and returning a list of overrides.
+  #     Overrides are introduced to provide native inputs to build the crates generated in `Cargo.nix`.
+  #     See `overlay/lib/overrides.nix` on how to create overrides and `overlay/overrides.nix` for a list of predefined overrides.
+  #     Most of the time, you can just use `overrides.all`. You can hand-pick overrides later if your build becomes too slow.
   # - `localPatterns` (optional):
   #     A list of regular expressions that specify what should be included in the sources of your workspace's crates.
   #     The expressions are relative to each crate's manifest directory.
@@ -100,11 +40,12 @@ let
   #     A list of activated features on your workspace's crates.
   #     Each feature should be of the form `<crate_name>[/<feature>]`.
   #     If `/<feature>` is omitted, the crate is activated with no default features.
+  #     The default behavior is to activate all crates with default features.
   # - `release` (optional): Whether to enable release mode (equivalent to `cargo build --release`), defaults to `true`.
   rustPkgs = pkgs.rustBuilder.makePackageSet' {
-    inherit rustPackageConfig;
-    rustChannel = "1.37";
+    rustChannel = "1.37.0";
     packageFun = import ./Cargo.nix;
+    packageOverrides = pkgs.rustBuilder.overrides.all;
   };
 in
   # `rustPkgs` now contains all crates in the dependency graph.

--- a/default.nix
+++ b/default.nix
@@ -45,7 +45,7 @@ let
   rustPkgs = pkgs.rustBuilder.makePackageSet' {
     rustChannel = "1.37.0";
     packageFun = import ./Cargo.nix;
-    packageOverrides = pkgs.rustBuilder.overrides.all;
+    packageOverrides = pkgs: pkgs.rustBuilder.overrides.all;
   };
 in
   # `rustPkgs` now contains all crates in the dependency graph.

--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -10,13 +10,15 @@ let
 
     rustLib = callPackage ./lib { };
 
-    makePackageSet = callPackage ./make-package-set/full.nix;
+    makePackageSet = callPackage ./make-package-set/full.nix { };
 
-    makePackageSet' = pkgs.callPackage ./make-package-set/simplified.nix;
+    makePackageSet' = pkgs.callPackage ./make-package-set/simplified.nix { };
 
     mkRustCrate = import ./mkcrate.nix;
 
     makeShell = callPackage ./make-shell.nix;
+
+    overrides = callPackage ./overrides.nix { };
   };
 in
 {

--- a/overlay/lib/default.nix
+++ b/overlay/lib/default.nix
@@ -4,6 +4,7 @@
   inherit (callPackage ./splice.nix { }) splicePackages;
   inherit (callPackage ./fetch.nix { }) fetchCrateLocal fetchCrateGit fetchCratesIo;
   inherit (callPackage ./profiles.nix { }) decideProfile genDrvsByProfile;
+  inherit (callPackage ./overrides.nix { }) makeOverride combineOverrides runOverride nullOverride;
 
   json2toml = pkgs.buildPackages.buildPackages.callPackage ./json2toml.nix { };
   toml2json = pkgs.buildPackages.buildPackages.callPackage ./toml2json.nix { };

--- a/overlay/lib/overrides.nix
+++ b/overlay/lib/overrides.nix
@@ -1,5 +1,5 @@
 # An overrider has the ability to modify the arguments passed to a function. It takes the original set of arguments
-# and returns a new set of arguments, which will then be merged will the original set to become the new arguments
+# and returns a new set of arguments, which will then be merged with the original set to become the new arguments
 # to the original function.
 # type Overrider = Attrs -> Attrs
 #

--- a/overlay/lib/overrides.nix
+++ b/overlay/lib/overrides.nix
@@ -1,0 +1,57 @@
+# An overrider has the ability to modify the arguments passed to a function. It takes the original set of arguments
+# and returns a new set of arguments, which will then be merged will the original set to become the new arguments
+# to the original function.
+# type Overrider = Attrs -> Attrs
+#
+# An override has the ability to modify the arguments passed to a function, and the attribute
+# set of the derivation returned by that function. It takes the original set of arguments and
+# optionally returns 2 overriders: `overrideArgs`, which overrides the argument set, and `overrideAttr`,
+# which overrides the derivation attributes.
+# See https://nixos.org/nixpkgs/manual/#sec-pkg-override for more information on `overrideArgs`, and
+# https://nixos.org/nixpkgs/manual/#sec-pkg-overrideAttrs for `overrideAttrs`.
+# type Override = Attrs -> { overrideArgs: Maybe Overrider, overrideAttrs: Maybe Overrider }
+{ }:
+let
+  combineOverriders = a: b:
+    if a == null then b
+    else if b == null then a
+    else oldAttrs: let attrs = oldAttrs // a oldAttrs; in attrs // b attrs;
+
+  nullOverriders = { overrideArgs = null; overrideAttrs = null; };
+in
+{
+  # Constructs an override for `mkRustCrate`.
+  # - `registry`, `name`, `version` specify which crates this override applies to.
+  # - `overrideArgs` overrides the argument set passed to `mkRustCrate`.
+  # - `overrideAttrs` overrides the attribute set of the derivation returned by `mkRustCrate`.
+  makeOverride = args@{ registry ? null, name ? null, version ? null, overrideArgs ? null, overrideAttrs ? null }:
+    assert overrideArgs != null || overrideAttrs != null;
+    let
+      matcher = builtins.intersectAttrs { registry = { }; name = { }; version = { }; } args;
+      overriders = { inherit overrideArgs overrideAttrs; };
+    in
+      args:
+        if builtins.intersectAttrs matcher args == matcher
+          then overriders
+          else nullOverriders;
+
+  combineOverrides = left: right: args:
+    let
+      leftOverriders = left args;
+      rightOverriders = right args;
+    in
+      {
+        overrideArgs = combineOverriders leftOverriders.overrideArgs rightOverriders.overrideArgs;
+        overrideAttrs = combineOverriders leftOverriders.overrideAttrs rightOverriders.overrideAttrs;
+      };
+
+  # Applies an override to a function.
+  runOverride = override: f: args:
+    let
+      overriders = override args;
+      drv = f (if overriders.overrideArgs == null then args else (args // overriders.overrideArgs args));
+    in
+      if overriders.overrideAttrs == null then drv else drv.overrideAttrs overriders.overrideAttrs;
+
+  nullOverride = _: nullOverriders;
+}

--- a/overlay/make-package-set/full.nix
+++ b/overlay/make-package-set/full.nix
@@ -44,10 +44,7 @@ lib.fix' (self:
     buildRustPackages = buildRustPackages';
     mkRustCrate =
       let
-        combinedOverride = builtins.foldl'
-          rustLib.combineOverrides
-          (_: { overrideArgs = null; overrideAttrs = null; })
-          packageOverrides;
+        combinedOverride = builtins.foldl' rustLib.combineOverrides rustLib.nullOverride packageOverrides;
       in
         rustLib.runOverride combinedOverride mkRustCrate';
     rustLib = rustLib // { fetchCrateLocal = path: (lib.sourceByRegex path localPatterns).outPath; };

--- a/overlay/make-package-set/simplified.nix
+++ b/overlay/make-package-set/simplified.nix
@@ -1,16 +1,18 @@
-args@{
+{
   pkgs,
   buildPackages,
   stdenv,
   rustBuilder,
+}:
+args@{
   rustChannel,
   packageFun,
-  rustPackageConfig ? _: { },
+  packageOverrides ? _: [ ],
   ...
 }:
 let
   rustChannel = buildPackages.rustChannelOf {
-    channel = "1.37.0";
+    channel = args.rustChannel;
   };
   inherit (rustChannel) cargo;
   rustc = rustChannel.rust.override {
@@ -18,13 +20,13 @@ let
       (rustBuilder.rustLib.realHostTriple stdenv.targetPlatform)
     ];
   };
-  extraArgs = builtins.removeAttrs args [ "stdenv" "pkgs" "buildPackages" "rustBuilder" "rustChannel" "packageFun" "rustPackageConfig" ];
+  extraArgs = builtins.removeAttrs args [ "rustChannel" "packageFun" "packageOverrides" ];
 in
 rustBuilder.makePackageSet (extraArgs // {
   inherit cargo rustc packageFun;
-  rustPackageConfig = rustPackageConfig pkgs;
+  packageOverrides = packageOverrides pkgs;
   buildRustPackages = buildPackages.rustBuilder.makePackageSet (extraArgs // {
       inherit cargo rustc packageFun;
-      rustPackageConfig = rustPackageConfig buildPackages;
+      packageOverrides = packageOverrides buildPackages;
   });
 })

--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -52,6 +52,7 @@ in rec {
     prost-build
     rand_os
     rand
+    rdkafka-sys
   ];
 
   capLints = makeOverride {
@@ -129,4 +130,14 @@ in rec {
       };
     }
     else nullOverride;
+
+  rdkafka-sys = makeOverride {
+    name = "rdkafka-sys";
+    overrideAttrs = drv: {
+      postConfigure = ''
+        ${drv.postConfigure or ""}
+        patchShebangs --build librdkafka/configure
+      '';
+    };
+  };
 }

--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -1,0 +1,120 @@
+{ rustLib, lib, buildPackages }:
+let
+  inherit (rustLib) makeOverride nullOverride;
+  envize = s: builtins.replaceStrings ["-"] ["_"] (lib.toUpper s);
+
+  patchOpenssl = pkgs: (pkgs.openssl.override {
+    # `perl` is only used at build time, but the derivation incorrectly uses host `perl` as an input.
+    perl = pkgs.buildPackages.buildPackages.perl;
+  }).overrideAttrs (_: {
+    installTargets = "install_sw";
+    outputs = [ "dev" "out" "bin" ];
+  });
+
+  joinOpenssl = openssl: buildPackages.symlinkJoin {
+    name = "openssl"; paths = with openssl; [ out dev ];
+  };
+
+  patchPostgresql = pkgs: (pkgs.postgresql.override {
+    openssl = patchOpenssl pkgs;
+  }).overrideAttrs (drv: {
+    # We don't need `systemd`. It breaks cross compilation.
+    buildInputs = builtins.filter (d: !lib.hasPrefix "systemd" d.name) drv.buildInputs;
+    configureFlags = builtins.filter (flag: flag != "--with-systemd") drv.configureFlags;
+  });
+
+
+  patchCurl = pkgs:
+    let
+      openssl = patchOpenssl pkgs;
+    in pkgs.curl.override {
+      inherit openssl;
+      nghttp2 = pkgs.nghttp2.override { inherit openssl; };
+      libssh2 = pkgs.libssh2.override { inherit openssl; };
+      libkrb5 = pkgs.libkrb5.override { inherit openssl; };
+    };
+
+in
+rec {
+  patches = [ patchOpenssl patchCurl ];
+
+  # Don't forget to add your new overrides here.
+  all = pkgs: [
+    capLints
+    (openssl-sys pkgs)
+    (curl-sys pkgs)
+    (libgit2-sys pkgs)
+    (pq-sys pkgs)
+    (prost-build pkgs)
+    (rand_os pkgs)
+  ];
+
+  capLints = makeOverride {
+    registry = "registry+https://github.com/rust-lang/crates.io-index";
+    overrideArgs = old: { rustcflags = old.rustcflags or [ ] ++ [ "--cap-lints" "warn" ]; };
+  };
+
+  openssl-sys = pkgs: makeOverride {
+    name = "openssl-sys";
+    overrideAttrs = _:
+      # We don't use key literals here, as they might collide if `hostPlatform == buildPlatform`.
+      builtins.listToAttrs [
+        { name = "${envize pkgs.stdenv.buildPlatform.config}_OPENSSL_DIR"; value = joinOpenssl (patchOpenssl pkgs.buildPackages); }
+        { name = "${envize pkgs.stdenv.hostPlatform.config}_OPENSSL_DIR"; value = joinOpenssl (patchOpenssl pkgs); }
+      ];
+  };
+
+  curl-sys = pkgs: makeOverride {
+    name = "curl-sys";
+    overrideAttrs = drv: {
+      propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [ (patchCurl pkgs) ];
+    };
+  };
+
+  libgit2-sys = pkgs:
+    if pkgs.stdenv.hostPlatform.isDarwin
+    then makeOverride {
+      name = "libgit2-sys";
+      overrideAttrs = drv: {
+        propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [
+          pkgs.libiconv
+          pkgs.darwin.apple_sdk.frameworks.Security
+          pkgs.darwin.apple_sdk.frameworks.CoreFoundation
+        ];
+      };
+    }
+    else nullOverride;
+
+  pq-sys = pkgs:
+    let
+      binEcho = s: "${pkgs.buildPackages.writeShellScriptBin "bin-echo" "echo ${s}"}/bin/bin-echo";
+    in
+      makeOverride {
+        name = "pq-sys";
+        overrideAttrs = _:
+          # We don't use key literals here, as they might collide if `hostPlatform == buildPlatform`.
+          # We can't use the host `pg_config` here either, as it might not run on build platform. `pq-sys` only needs
+          # to know the `lib` directory for `libpq`, so just create a fake binary that gives it exactly that.
+          builtins.listToAttrs [
+            { name = "PG_CONFIG_${envize pkgs.stdenv.buildPlatform.config}"; value = binEcho "${(patchPostgresql pkgs.buildPackages).lib}/lib"; }
+            { name = "PG_CONFIG_${envize pkgs.stdenv.hostPlatform.config}"; value = binEcho "${(patchPostgresql pkgs).lib}/lib"; }
+          ];
+      };
+
+  prost-build = pkgs: makeOverride {
+    name = "prost-build";
+    overrideAttrs = _: {
+      PROTOC = "${pkgs.buildPackages.buildPackages.protobuf}/bin/protoc";
+    };
+  };
+
+  rand_os = pkgs:
+    if pkgs.stdenv.hostPlatform.isDarwin
+    then makeOverride {
+      name = "rand_os";
+      overrideAttrs = drv: {
+        propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [ pkgs.darwin.apple_sdk.frameworks.Security ];
+      };
+    }
+    else nullOverride;
+}

--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -38,7 +38,7 @@ in
 rec {
   patches = [ patchOpenssl patchCurl ];
 
-  # Don't forget to add your new overrides here.
+  # Don't forget to add new overrides here.
   all = pkgs: [
     capLints
     (openssl-sys pkgs)
@@ -47,6 +47,7 @@ rec {
     (pq-sys pkgs)
     (prost-build pkgs)
     (rand_os pkgs)
+    (rand pkgs)
   ];
 
   capLints = makeOverride {
@@ -117,4 +118,15 @@ rec {
       };
     }
     else nullOverride;
+
+  rand = pkgs:
+    if pkgs.stdenv.hostPlatform.isDarwin
+    then makeOverride {
+      name = "rand";
+      overrideAttrs = drv: {
+        propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [ pkgs.darwin.apple_sdk.frameworks.Security ];
+      };
+    }
+    else nullOverride;
+
 }


### PR DESCRIPTION
This PR replaces `config` with `overrides`, a more reusable and composable mechanism to provide native inputs to Rust crates.   