### PR TITLE
Propagate environment variables to root crates

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -57,6 +57,6 @@ in
 rec {
   package = rustPkgs."unknown".cargo2nix."0.5.0" { };
   shell = pkgs.mkShell {
-    inputsFrom = [ package ];
+    inputsFrom = [ (rustPkgs.noBuild."unknown".cargo2nix."0.5.0" { }) ];
   };
 }

--- a/default.nix
+++ b/default.nix
@@ -54,6 +54,9 @@ in
   #   `rustPkgs.<registry>.<crate>.<version>{ compileMode = "test"; }`.
   # To build bench binaries (equivalent to `cargo build --benches`), use
   #   `rustPkgs.<registry>.<crate>.<version>{ compileMode = "bench"; }`.
-{
+rec {
   package = rustPkgs."unknown".cargo2nix."0.5.0" { };
+  shell = pkgs.mkShell {
+    inputsFrom = [ package ];
+  };
 }

--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -16,6 +16,8 @@ let
 
     mkRustCrate = import ./mkcrate.nix;
 
+    mkRustCrateNoBuild = callPackage ./mkcrate-nobuild.nix;
+
     makeShell = callPackage ./make-shell.nix;
 
     overrides = callPackage ./overrides.nix { };

--- a/overlay/mkcrate-nobuild.nix
+++ b/overlay/mkcrate-nobuild.nix
@@ -1,0 +1,37 @@
+# Creates a derivation for a crate for inputs propagation only.
+{ lib, stdenv }:
+{
+  release, # Compiling in release mode?
+  name,
+  version,
+  registry,
+  src,
+  features,
+  dependencies,
+  devDependencies,
+  buildDependencies,
+  compileMode ? "build",
+  profile,
+  meta ? { },
+  rustcflags ? [ ],
+  rustcBuildFlags ? [ ],
+}:
+with lib; with builtins;
+let
+  inherit
+    (({ right, wrong }: { runtimeDependencies = right; buildtimeDependencies = wrong; })
+      (partition (drv: drv.stdenv.hostPlatform == stdenv.hostPlatform)
+        (concatLists [
+          (attrValues dependencies)
+          (optionals (compileMode == "test") (attrValues devDependencies))
+          (attrValues buildDependencies)
+        ])))
+    runtimeDependencies buildtimeDependencies;
+in stdenv.mkDerivation {
+  name = "crate-${name}-${version}";
+  buildInputs = runtimeDependencies;
+  propagatedBuildInputs = concatMap (drv: drv.propagatedBuildInputs) runtimeDependencies;
+  nativeBuildInputs = buildtimeDependencies;
+  phases = "installPhase fixupPhase";
+  installPhase = "mkdir -p $out";
+}

--- a/overlay/mkcrate-nobuild.nix
+++ b/overlay/mkcrate-nobuild.nix
@@ -29,9 +29,7 @@ let
     runtimeDependencies buildtimeDependencies;
 in stdenv.mkDerivation {
   name = "crate-${name}-${version}";
-  buildInputs = runtimeDependencies;
   propagatedBuildInputs = concatMap (drv: drv.propagatedBuildInputs) runtimeDependencies;
-  nativeBuildInputs = buildtimeDependencies;
   phases = "installPhase fixupPhase";
   installPhase = "mkdir -p $out";
   preferLocalBuild = true;

--- a/overlay/mkcrate-nobuild.nix
+++ b/overlay/mkcrate-nobuild.nix
@@ -34,4 +34,6 @@ in stdenv.mkDerivation {
   nativeBuildInputs = buildtimeDependencies;
   phases = "installPhase fixupPhase";
   installPhase = "mkdir -p $out";
+  preferLocalBuild = true;
+  allowSubstitutes = false;
 }

--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -52,6 +52,8 @@ let
     '';
     phases = "installPhase fixupPhase";
     installPhase = "mkdir -p $out";
+    preferLocalBuild = true;
+    allowSubstitutes = false;
   };
 
 in rec {

--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -39,8 +39,23 @@ let
       libkrb5 = pkgs.libkrb5.override { inherit openssl; };
     };
 
+  propagateEnv = name: envs: buildPackages.stdenv.mkDerivation {
+    name = "${name}-propagate-env";
+    setupHook = buildPackages.writeText "exports.sh" ''
+      ${name}-setup-env() {
+        ${lib.concatMapStringsSep
+            "\n"
+            ({ name, value }: "export ${name}=${lib.escapeShellArg value}")
+            envs}
+      }
+      addEnvHooks "$hostOffset" ${name}-setup-env
+    '';
+    phases = "installPhase fixupPhase";
+    installPhase = "mkdir -p $out";
+  };
+
 in rec {
-  patches = { inherit patchOpenssl patchCurl patchPostgresql joinOpenssl; };
+  patches = { inherit patchOpenssl patchCurl patchPostgresql joinOpenssl propagateEnv; };
 
   # Don't forget to add new overrides here.
   all = [
@@ -62,12 +77,14 @@ in rec {
 
   openssl-sys = makeOverride {
     name = "openssl-sys";
-    overrideAttrs = _:
-      # We don't use key literals here, as they might collide if `hostPlatform == buildPlatform`.
-      builtins.listToAttrs [
-        { name = "${envize pkgs.stdenv.buildPlatform.config}_OPENSSL_DIR"; value = joinOpenssl (patchOpenssl pkgs.buildPackages); }
-        { name = "${envize pkgs.stdenv.hostPlatform.config}_OPENSSL_DIR"; value = joinOpenssl (patchOpenssl pkgs); }
+    overrideAttrs = drv: {
+      propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [
+        (propagateEnv "openssl-sys" [
+          { name = "${envize pkgs.stdenv.buildPlatform.config}_OPENSSL_DIR"; value = joinOpenssl (patchOpenssl pkgs.buildPackages); }
+          { name = "${envize pkgs.stdenv.hostPlatform.config}_OPENSSL_DIR"; value = joinOpenssl (patchOpenssl pkgs); }
+        ])
       ];
+    };
   };
 
   curl-sys = makeOverride {
@@ -96,20 +113,26 @@ in rec {
     in
       makeOverride {
         name = "pq-sys";
-        overrideAttrs = _:
-          # We don't use key literals here, as they might collide if `hostPlatform == buildPlatform`.
-          # We can't use the host `pg_config` here either, as it might not run on build platform. `pq-sys` only needs
+        overrideAttrs = drv: {
+          # We can't use the host `pg_config` here, as it might not run on build platform. `pq-sys` only needs
           # to know the `lib` directory for `libpq`, so just create a fake binary that gives it exactly that.
-          builtins.listToAttrs [
-            { name = "PG_CONFIG_${envize pkgs.stdenv.buildPlatform.config}"; value = binEcho "${(patchPostgresql pkgs.buildPackages).lib}/lib"; }
-            { name = "PG_CONFIG_${envize pkgs.stdenv.hostPlatform.config}"; value = binEcho "${(patchPostgresql pkgs).lib}/lib"; }
+          propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [
+            (propagateEnv "pq-sys" [
+              { name = "PG_CONFIG_${envize pkgs.stdenv.buildPlatform.config}"; value = binEcho "${(patchPostgresql pkgs.buildPackages).lib}/lib"; }
+              { name = "PG_CONFIG_${envize pkgs.stdenv.hostPlatform.config}"; value = binEcho "${(patchPostgresql pkgs).lib}/lib"; }
+            ])
           ];
+        };
       };
 
   prost-build = makeOverride {
     name = "prost-build";
-    overrideAttrs = _: {
-      PROTOC = "${pkgs.buildPackages.buildPackages.protobuf}/bin/protoc";
+    overrideAttrs = drv: {
+      propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [
+        (propagateEnv "prost-build" [
+          { name = "PROTOC"; value = "${pkgs.buildPackages.buildPackages.protobuf}/bin/protoc"; }
+        ])
+      ];
     };
   };
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+with import ./. { crossSystem = null; }; shell


### PR DESCRIPTION
This PR allows overrides to propagate environment variables further up the dependency graph, which reduces the work to create a development shell.

CC @edude03 @antigravityla.

Resolves #33 
Resolves #34