### PR TITLE
Include integration test binaries in test mode

### DIFF
--- a/overlay/make-package-set/full.nix
+++ b/overlay/make-package-set/full.nix
@@ -11,7 +11,7 @@
   cargo,
   rustc,
   buildRustPackages ? null,
-  localPatterns ? [ ''^(src)(/.*)?'' ''[^/]*\.(rs|toml)$'' ],
+  localPatterns ? [ ''^(src|test)(/.*)?'' ''[^/]*\.(rs|toml)$'' ],
   packageOverrides ? [ ],
   fetchCrateAlternativeRegistry ? _: throw "fetchCrateAlternativeRegistry is required, but not specified in makePackageSet",
   release ? null,


### PR DESCRIPTION
### Fixed

* Add top-level `tests` directory to `localPatterns` in `overlay/mkcrate.nix`.

As described in #40, `cargo2nix` currently does not output integration tests by default when building the crate in test mode. This is because `localPatterns` does not include the top-level `tests` directory in the default path regex. This directory is standard for any Cargo project, and the current behavior of not including integration tests when `compileMode = "test"` is quite surprising, especially for a new user. I believe it should be fine to include this directory by default, if it exists.

Fixes #40.