### PR TITLE
Document broken builtins.fromTOML in Nix 2.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,22 @@ for the `crates-io` public crates.
 1. Many `crates.io` public crates may not build using the current Rust compiler,
    unless a lint cap is put on these crates. For instance, `cargo2nix` caps all
    warnings in the `failure` crate to just `warn`.
+2. Nix 2.1.3 ships with a broken `builtins.fromTOML` function which is unable to
+   parse lines of TOML that look like this:
+
+   ```toml
+   [target.'cfg(target_os = "linux")'.dependencies.rscam]
+   ```
+
+   If Nix fails to parse your project's `Cargo.toml` manifest with an error
+   similar to the one below, please upgrade to a newer version of Nix. Versions
+   2.3.1 and newer are not affected by this bug. If upgrading is not an option,
+   removing the inner whitespace from the problematic keys should work around
+   this issue.
+
+   ```
+   error: while parsing a TOML string at /nix/store/.../overlay/mkcrate.nix:31:14: Bare key 'cfg(target_os = "linux")' cannot contain whitespace at line 45
+   ```
 
 ## Design
 


### PR DESCRIPTION
### Changed

* Document broken `fromTOML` builtin as a common issue in `README.md`.

It seems that Nix 2.1.3 provides a bugged version of `builtins.fromTOML` which chokes when parsing `Cargo.toml` manifests that have `cfg(...)` keys in them, as shown below:

```toml
[target.'cfg(target_os = "linux")'.dependencies.rscam]
```

Removing the whitespace around the equal sign resolves the issue for now, but ultimately, the best thing to do is to upgrade to a newer version of Nix. I can confirm on my work machine that Nix 2.3.1 does not have this issue. If we can find out what precise version of Nix fixed this bug, we should probably update the `README.md` text at a later date.