### PR TITLE
Generate a set of all workspace crates

### DIFF
--- a/Cargo.nix
+++ b/Cargo.nix
@@ -11,7 +11,7 @@
   lib,
 }:
 let
-  inherit (rustLib) fetchCratesIo fetchCrateLocal fetchCrateGit expandFeatures decideProfile genDrvsByProfile;
+  inherit (rustLib) fetchCratesIo fetchCrateLocal fetchCrateGit fetchCrateAlternativeRegistry expandFeatures decideProfile genDrvsByProfile;
   profilesByName = {
   };
   rootFeatures' = expandFeatures rootFeatures;
@@ -22,6 +22,9 @@ let
       let drv = drvs.${profileName}; in if compileMode == null then drv else drv.override { inherit compileMode; };
 in
 {
+  workspace = {
+    cargo2nix = rustPackages."unknown".cargo2nix."0.5.0";
+  };
   "registry+https://github.com/rust-lang/crates.io-index".adler32."1.0.4" = overridableMkRustCrate ({ profileName, profile }: {
     inherit release profile;
     name = "adler32";

--- a/default.nix
+++ b/default.nix
@@ -55,11 +55,16 @@ in
   #   `rustPkgs.<registry>.<crate>.<version>{ compileMode = "test"; }`.
   # To build bench binaries (equivalent to `cargo build --benches`), use
   #   `rustPkgs.<registry>.<crate>.<version>{ compileMode = "bench"; }`.
+  # For convenience, you can also refer to the crates in the workspace using
+  #   `rustPkgs.workspace.<crate>`.
 rec {
   inherit rustPkgs;
-  package = rustPkgs.unknown.cargo2nix."0.5.0" { };
+  package = rustPkgs.workspace.cargo2nix { };
+  # `noBuild` is a special crate set used to create a development shell
+  # containing all native dependencies provided by the overrides above.
+  # `cargo build` with in the shell should just work.
   shell = pkgs.mkShell {
-    inputsFrom = [ (rustPkgs.noBuild.unknown.cargo2nix."0.5.0" { }) ];
+    inputsFrom =  pkgs.lib.mapAttrsToList (_: pkg: pkg { }) rustPkgs.noBuild.workspace;
     nativeBuildInputs = with rustPkgs; [ cargo rustc ];
   };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,6 +137,15 @@ fn main() {
         }
         writeln!(f, "in")?;
         writeln!(f, "{{")?;
+        {
+            let mut f = f.indent(2);
+            writeln!(f, "workspace = {{")?;
+            for pkg in root_pkgs.iter() {
+                writeln!(f.indent(2), "{} = {}.{};", pkg.name(), scope.crates, display_pkg_id_nix(pkg.package_id()))?;
+            }
+            writeln!(f, "}};")?;
+        }
+
         for rpkg in rpkgs_by_id.values() {
             writeln!(
                 f.indent(2),


### PR DESCRIPTION
Becase `unknown.<crate>.<version>` is just too mouthful.