### PR TITLE
Exclude generated Cargo.nix from the repo language stat

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# https://help.github.com/en/github/administering-a-repository/customizing-how-changed-files-appear-on-github
+
+Cargo.nix linguist-generated=true
+


### PR DESCRIPTION
This will make language stat of the repo more sensible.