### PR TITLE
Less verbose cargo

### DIFF
--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -23,6 +23,7 @@
   meta ? { },
   rustcflags ? [ ],
   rustcBuildFlags ? [ ],
+  NIX_DEBUG ? 0,
 }:
 with builtins; with lib;
 let
@@ -92,7 +93,7 @@ let
         else "--features ${concatStringsSep "," featuresWithoutDefault}";
     in
       ''
-        cargo build -vvv ${optionalString release "--release"} --target ${host-triple} ${buildMode} \
+        cargo build $CARGO_VERBOSE ${optionalString release "--release"} --target ${host-triple} ${buildMode} \
           ${featuresArg} ${optionalString (!hasDefaultFeature) "--no-default-features"}
       '';
 
@@ -107,6 +108,7 @@ let
       runtimeDependencies buildtimeDependencies;
 
   drvAttrs = {
+    inherit NIX_DEBUG;
     name = "crate-${name}-${version}${optionalString (compileMode != "build") "-${compileMode}"}";
     inherit src version meta;
     crateName = manifest.lib.name or (replaceChars ["-"] ["_"] name);
@@ -188,6 +190,7 @@ let
 
     setBuildEnv = ''
       . ${./utils.sh}
+      export CARGO_VERBOSE=`cargoVerbosityLevel $NIX_DEBUG`
       export NIX_RUST_METADATA=`extractHash $out`
       export CARGO_HOME=`pwd`/.cargo
       mkdir -p deps build_deps

--- a/overlay/utils.sh
+++ b/overlay/utils.sh
@@ -196,3 +196,16 @@ install_crate() {
 --arg procmacro "$isProcMacro" \
 --arg version $version >$out/.cargo-info
 }
+
+cargoVerbosityLevel() {
+  level=${1:-0}
+  verbose_flag=""
+
+  if (( level >= 1 )); then
+    verbose_flag="-v"
+  elif (( level >= 7 )); then
+    verbose_flag="-vv"
+  fi
+
+  echo ${verbose_flag}
+}


### PR DESCRIPTION
During the work on Cumbertrade I've noticed that `cargo` is producing a lot of noise during a build of `cargo2nix`-ed packages. Related issue is here: https://github.com/tenx-tech/engineering-program/issues/721

This PR won't just remove the `-vvv` flag from `cargo` invocation in `mkRustCrate`, but will make the verbosity level configurable since I believe that this high verbosity was added for a reason and still might be useful in some cases.

cc @workflow @ebkalderon 