### PR TITLE
Add override for ring instead of webpki-roots

### DIFF
--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -68,7 +68,7 @@ in rec {
     rand_os
     rand
     rdkafka-sys
-    webpki-roots
+    ring
   ];
 
   capLints = makeOverride {
@@ -165,9 +165,9 @@ in rec {
     };
   };
   
-  webpki-roots = if pkgs.stdenv.hostPlatform.isDarwin
+  ring = if pkgs.stdenv.hostPlatform.isDarwin
     then makeOverride {
-      name = "webpki-roots";
+      name = "ring";
       overrideAttrs = drv: {
         propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [ pkgs.darwin.apple_sdk.frameworks.Security ];
       };


### PR DESCRIPTION
`Security` is actually a [direct build input](https://github.com/briansmith/ring/blob/4c392ad338f61ea166a29c83d4208e8edfecc6ca/src/rand.rs#L405) for `ring`, not `webpki-roots`. `webpki-roots` indirectly depends on `ring` and happens to include a [binary](https://github.com/ctz/webpki-roots/blob/master/src/bin/process_cert.rs), which sets off the linking error. 

As a side note, we should always apply overrides to the "deepest" crate in the dependency tree. This benefits more crates and reduces the number of overrides needed.

CC @port3000.