### PR TITLE
Fix building lib targets with non-standard names

### DIFF
--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -95,7 +95,6 @@ let
     inherit NIX_DEBUG;
     name = "crate-${name}-${version}${optionalString (compileMode != "build") "-${compileMode}"}";
     inherit src version meta;
-    crateName = replaceChars ["-"] ["_"] name;
     buildInputs = runtimeDependencies;
     propagatedBuildInputs = concatMap (drv: drv.propagatedBuildInputs) runtimeDependencies;
     nativeBuildInputs = [ cargo buildPackages.pkg-config ] ++ buildtimeDependencies;
@@ -192,6 +191,10 @@ let
       isProcMacro="$( \
         remarshal -if toml -of json Cargo.original.toml \
         | jq -r 'if .lib."proc-macro" or .lib."proc_macro" then "1" else "" end' \
+      )"
+      crateName="$(
+        remarshal -if toml -of json Cargo.original.toml \
+        | jq -r 'if .lib."name" then .lib."name" else "${replaceChars ["-"] ["_"] name}" end' \
       )"
       . ${./utils.sh}
       export CARGO_VERBOSE=`cargoVerbosityLevel $NIX_DEBUG`


### PR DESCRIPTION
### Fixed

* Fix building `[lib]` targets with non-standard names.

Currently, `cargo2nix` assumes that all crate library targets follow the format of `lib<crate_name_with_underscores>.rlib`, which isn't always true. It turns out that the library target of the [`sha-1`] crate uses a non-standard rlib name which doesn't match the name of the crate, thanks to the `lib.name` attribute in the `Cargo.toml`. Because of this, the `sha-1` crate doesn't build correctly in `cargo2nix`.

[`sha-1`]: https://github.com/RustCrypto/hashes/tree/master/sha1

This commit fixes the build by first checking whether the `lib.name` attribute exists in the crate's `Cargo.toml` first, and if it doesn't exist, it will fall back to `crateName`.

CC @port3000 