### PR TITLE
Prepare release 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "cargo2nix"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "cargo 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -25,7 +25,7 @@ in
 {
   cargo2nixVersion = "0.6.0";
   workspace = {
-    cargo2nix = rustPackages."unknown".cargo2nix."0.6.0";
+    cargo2nix = rustPackages."unknown".cargo2nix."0.7.0";
   };
   "registry+https://github.com/rust-lang/crates.io-index".adler32."1.0.4" = overridableMkRustCrate (profileName: rec {
     name = "adler32";
@@ -237,9 +237,9 @@ in
     };
   });
   
-  "unknown".cargo2nix."0.6.0" = overridableMkRustCrate (profileName: rec {
+  "unknown".cargo2nix."0.7.0" = overridableMkRustCrate (profileName: rec {
     name = "cargo2nix";
-    version = "0.6.0";
+    version = "0.7.0";
     registry = "unknown";
     src = fetchCrateLocal ./.;
     dependencies = {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo2nix"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2018"
 license = "MIT"
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 TenX Pte. Ltd.
+Copyright (c) 2020 TenX Pte. Ltd.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### Changed

* Bump crate version to 0.7.0 and regenerate `Cargo.nix`.

We have had many significant updates to `cargo2nix` recently, and I believe this warrants tagging a brand-new release.