### PR TITLE
Add macOS package override for fsevent-sys

### DIFF
--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -62,6 +62,7 @@ in rec {
     capLints
     openssl-sys
     curl-sys
+    fsevent-sys
     libgit2-sys
     pq-sys
     prost-build
@@ -92,6 +93,15 @@ in rec {
     name = "curl-sys";
     overrideAttrs = drv: {
       propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [ (patchCurl pkgs) ];
+    };
+  };
+
+  fsevent-sys = makeOverride {
+    name = "fsevent-sys";
+    overrideAttrs = drv: {
+      propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [
+        pkgs.darwin.apple_sdk.frameworks.CoreServices
+      ];
     };
   };
 


### PR DESCRIPTION
### Added

* Add macOS package override for `fsevent-sys` linking against `CoreServices`.

This commit should allow `fsevent-sys`, and in turn [rust-analyzer](https://github.com/rust-analyzer/rust-analyzer), to successfully build under macOS with `cargo2nix`. See the commit message description for why I chose to do this.

In case you're curious, the steps for building `rust-analyzer` on macOS Mojave are as follows:

1. `git clone https://github.com/rust-analyzer/rust-analyzer` 
2. Create a minimal `default.nix` based on the one in this repository, targeting the `ra_lsp_server` crate specifically.
3. Change the Rust version to `1.40.0`.
4. Run `cargo2nix -f` at the `rust-analyzer` repo root.
5. Run `nix-env -if default.nix -A package --arg crossSystem null`.
6. You now have `ra_lsp_server` available in your environment!