### PR TITLE
Set PKG_CONFIG_ALLOW_CROSS if host and build platforms differ

### DIFF
--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -64,6 +64,7 @@ in rec {
     fsevent-sys
     libgit2-sys
     openssl-sys
+    pkg-config
     pq-sys
     prost-build
     rand
@@ -117,6 +118,19 @@ in rec {
       ];
     };
   };
+
+  pkg-config = if pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform
+    then makeOverride {
+      name = "pkg-config";
+      overrideAttrs = drv: {
+        propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [
+          (propagateEnv "pkg-config" [
+            { name = "PKG_CONFIG_ALLOW_CROSS"; value = "1"; }
+          ])
+        ];
+      };
+    }
+    else nullOverride;
 
   pq-sys =
     let

--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -119,7 +119,7 @@ in rec {
     };
   };
 
-  pkg-config = if pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform
+  pkg-config = if pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform
     then makeOverride {
       name = "pkg-config";
       overrideAttrs = drv: {


### PR DESCRIPTION
The [`pkg-config`](https://crates.io/crates/pkg-config) crate cannot cross-compile packages unless the `PKG_CONFIG_ALLOW_CROSS` environment variable is set, throwing the [`CrossCompilation`] error otherwise.

[`CrossCompilation`]: https://docs.rs/pkg-config/0.3.17/pkg_config/enum.Error.html#variant.CrossCompilation

This commit automatically sets `PKG_CONFIG_ALLOW_CROSS=1` as a propagated environment variable for any dependency tree which depends on `pkg-config` if the `stdenv` host platform and build platform differ.

This should fix cross-compilation of certain crates which rely on `pkg-config`, such as [`curl-sys`](https://crates.io/crates/curl-sys).