### PR TITLE
Fix codegen regression for Git dependencies

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -88,10 +88,21 @@ pub struct Crate {
 
 #[derive(Debug, Serialize)]
 pub enum Source {
-    CratesIo { sha256: String },
-    Git { rev: String, sha256: String },
-    Local { path: PathBuf },
-    Registry { index: String, sha256: String },
+    CratesIo {
+        sha256: String,
+    },
+    Git {
+        url: String,
+        rev: String,
+        sha256: String,
+    },
+    Local {
+        path: PathBuf,
+    },
+    Registry {
+        index: String,
+        sha256: String,
+    },
 }
 
 #[derive(Debug, Serialize)]
@@ -133,6 +144,7 @@ fn to_source(pkg: &ResolvedPackage<'_>, cwd: &Path) -> Source {
         }
     } else if id.source_id().is_git() {
         Source::Git {
+            url: id.source_id().url().to_string(),
             rev: id
                 .source_id()
                 .precise()


### PR DESCRIPTION
### Fixed

* Add missing `url` field to `Source::Git` enum variant.

This fixes a regression introduced by #80 which results in a templating failure for Git crate dependencies. I noticed it after running `cargo2nix -f` against the latest commit of `rust-analyzer`.

Since `cargo2nix` 0.8.1 hasn't been officially released yet, this requires no version number increase.