### PR TITLE
Clean up some workspace resolution code

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -348,23 +348,6 @@ pub struct ResolvedPackage<'a> {
     checksum: Option<Cow<'a, str>>,
 }
 
-#[derive(Debug)]
-struct ResolvedDependency<'a> {
-    extern_name: String,
-    pkg: &'a Package,
-    optionality: Optionality<'a>,
-    platforms: Option<Vec<&'a Platform>>,
-}
-
-#[derive(PartialEq, Eq, Debug)]
-enum Optionality<'a> {
-    Required,
-    Optional {
-        required_by_pkgs: BTreeSet<PackageName<'a>>,
-        activated_by_features: BTreeSet<RootFeature<'a>>,
-    },
-}
-
 impl<'a> ResolvedPackage<'a> {
     fn new(
         pkg: &'a Package,
@@ -460,6 +443,23 @@ impl<'a> ResolvedPackage<'a> {
             .map(|(_, d)| &mut d.optionality)
             .chain(self.features.values_mut())
     }
+}
+
+#[derive(Debug)]
+struct ResolvedDependency<'a> {
+    extern_name: String,
+    pkg: &'a Package,
+    optionality: Optionality<'a>,
+    platforms: Option<Vec<&'a Platform>>,
+}
+
+#[derive(PartialEq, Eq, Debug)]
+enum Optionality<'a> {
+    Required,
+    Optional {
+        required_by_pkgs: BTreeSet<PackageName<'a>>,
+        activated_by_features: BTreeSet<RootFeature<'a>>,
+    },
 }
 
 impl<'a> Default for Optionality<'a> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -244,7 +244,7 @@ fn simplify_optionality<'a, 'b: 'a>(
     }
 }
 
-fn all_features<'a>(p: &'a Package) -> impl 'a + Iterator<Item = Feature<'a>> {
+fn all_features(p: &Package) -> impl Iterator<Item = Feature> + '_ {
     let features = p.summary().features();
     features
         .keys()

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,18 +165,8 @@ fn generate_cargo_nix(mut out: impl io::Write) {
     };
     let root_manifest_path = find_root_manifest_for_wd(config.cwd()).unwrap();
     let ws = Workspace::new(&root_manifest_path, &config).unwrap();
-
-    let resolve = resolve_ws_with_opts(
-        &ws,
-        ResolveOpts {
-            dev_deps: true,
-            features: Rc::new(Default::default()),
-            all_features: true,
-            uses_default_features: true,
-        },
-        &Packages::All.to_package_id_specs(&ws).unwrap(),
-    )
-    .unwrap();
+    let specs = Packages::All.to_package_id_specs(&ws).unwrap();
+    let resolve = resolve_ws_with_opts(&ws, ResolveOpts::everything(), &specs).unwrap();
 
     let pkgs_by_id = resolve
         .pkg_set

--- a/src/main.rs
+++ b/src/main.rs
@@ -577,5 +577,5 @@ where
         None => return true,
     };
 
-    return iter.all(|x| x == first);
+    iter.all(|x| x == first)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -281,17 +281,9 @@ fn mark_required(
     ws: &Workspace,
     rpkgs_by_id: &mut BTreeMap<PackageId, ResolvedPackage>,
 ) {
-    let resolve = resolve_ws_with_opts(
-        ws,
-        ResolveOpts {
-            dev_deps: true,
-            features: Rc::new(Default::default()),
-            all_features: false,
-            uses_default_features: false,
-        },
-        &[PackageIdSpec::from_package_id(root_pkg.package_id())],
-    )
-    .unwrap();
+    let spec = PackageIdSpec::from_package_id(root_pkg.package_id());
+    let resolve =
+        resolve_ws_with_opts(ws, ResolveOpts::new(true, &[], false, false), &[spec]).unwrap();
 
     let root_pkg_name = root_pkg.name().as_str();
     // Dependencies that are activated, even when no features are activated, must be required.

--- a/src/main.rs
+++ b/src/main.rs
@@ -314,6 +314,7 @@ fn activate<'a>(
         "default" => (vec![], true),
         other => (vec![other.to_string()], false),
     };
+
     let resolve = resolve_ws_with_opts(
         ws,
         ResolveOpts::new(true, &features[..], false, uses_default),


### PR DESCRIPTION
### Changed

 * Simplify `resolve_ws_with_opts()` invocations in several methods by using `ResolveOpts::everything()` and `ResolveOpts::new()` to reduce boilerplate.
* Remove explicit return in `all_eq()`.
* Remove explicit lifetimes from `all_features()`.
* Add single trailing newline for readability.
* Keep data structures close to their `impl` blocks.