### PR TITLE
Don't cross-compile cargo2nix to musl by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This project assumes that the [Nix package manager](https://nixos.org/nix) is
 already installed on your machine. Run the command below to install `cargo2nix`:
 
 ```bash
-nix-env -iA package -f https://github.com/tenx-tech/cargo2nix/tarball/master --arg crossSystem null
+nix-env -iA package -f https://github.com/tenx-tech/cargo2nix/tarball/master
 ```
 
 ## How to use this for your Rust projects

--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,7 @@
   },
   system ? builtins.currentSystem,
   overlays ? [ ],
-  crossSystem ? (import nixpkgs {}).lib.systems.examples.musl64,
+  crossSystem ? null,
 }:
 let
   # 1. Setup nixpkgs with nixpkgs-mozilla overlay and cargo2nix overlay.


### PR DESCRIPTION
### Changed

* Specify `crossSystem ? null` for the `cargo2nix` Rust crate.

Since the `cargo2nix` crate cannot even compile under `musl` on Linux anyway, thanks to the `nix-prefetch-git` dependency added in #62, it no longer makes sense to recommend cross-compiling to that platform by default. Instead, we should default to compiling for the system and `libc` of the build platform, where the command is likely to be running anyway.

This is not a breaking change for downstream users of the `cargo2nix` overlay. It also should not affect future installations of the `cargo2nix` CLI tool because the README already recommended installing with `--arg crossSystem null` anyway.

Fixes #88.