### PR TITLE
Switch to new Cachix in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,8 @@ jobs:
           name: Build
           command: |
             USER=root cachix use cargo2nix
-            nix-build -A ci --show-trace | cachix push cargo2nix
+            cachix push cargo2nix -w &
+            nix-build -A ci --show-trace
           no_output_timeout: 5h
       - save_cache:
           key: nix-store

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ jobs:
           name: Install cachix
           command: |
             nix-env -iA cachix -f https://cachix.org/api/v1/install
-            USER=root cachix use tenx-cargo2nix
-            USER=root cachix push tenx-cargo2nix -w &
+            USER=root cachix use cargo2nix
+            USER=root cachix push cargo2nix -w &
       - run:
           name: Build
           command: nix-build ./. -A ci --show-trace --no-out-link

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,11 +12,11 @@ jobs:
           name: Install cachix
           command: |
             nix-env -iA cachix -f https://cachix.org/api/v1/install
-            USER=root cachix use cargo2nix
-            USER=root cachix push cargo2nix -w &
       - run:
           name: Build
-          command: nix-build ./. -A ci --show-trace --no-out-link
+          command: |
+            USER=root cachix use cargo2nix
+            nix-build -A ci --show-trace | cachix push cargo2nix
           no_output_timeout: 5h
       - save_cache:
           key: nix-store


### PR DESCRIPTION
### Changed

* Switch to new `cargo2nix` cache in CircleCI. This change is coupled with the addition of `CACHIX_SIGNING_KEY` to the build-time secrets.
* Push `nix-build` output inside CI build step, using [this configuration](https://github.com/tweag/clodl/blob/master/.circleci/config.yml) as reference.

Should hopefully fix CI for #89.