### PR TITLE
Make packageOverrides default to overrides.all

### DIFF
--- a/overlay/make-package-set/full.nix
+++ b/overlay/make-package-set/full.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   lib,
+  rustBuilder,
   rustLib,
   stdenv,
   mkRustCrate,
@@ -12,7 +13,7 @@
   rustc,
   buildRustPackages ? null,
   localPatterns ? [ ''^(src|tests)(/.*)?'' ''[^/]*\.(rs|toml)$'' ],
-  packageOverrides ? [ ],
+  packageOverrides ? rustBuilder.overrides.all,
   fetchCrateAlternativeRegistry ? _: throw "fetchCrateAlternativeRegistry is required, but not specified in makePackageSet",
   release ? null,
   rootFeatures ? null,

--- a/overlay/make-package-set/simplified.nix
+++ b/overlay/make-package-set/simplified.nix
@@ -7,7 +7,7 @@
 args@{
   rustChannel,
   packageFun,
-  packageOverrides ? _: rustBuilder.overrides.all,
+  packageOverrides ? pkgs: pkgs.rustBuilder.overrides.all,
   ...
 }:
 let

--- a/overlay/make-package-set/simplified.nix
+++ b/overlay/make-package-set/simplified.nix
@@ -7,7 +7,7 @@
 args@{
   rustChannel,
   packageFun,
-  packageOverrides ? _: [ ],
+  packageOverrides ? _: rustBuilder.overrides.all,
   ...
 }:
 let


### PR DESCRIPTION
### Changed

* Make `packageOverrides` default to `rustBuilder.overrides.all`.

Follow-up to https://github.com/tenx-tech/cargo2nix/pull/93#pullrequestreview-375921456.