### PR TITLE
Attempt to copy tempfile if atomic rename fails

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -163,9 +163,11 @@ fn write_to_file(file: impl AsRef<Path>) -> Result<()> {
 
     generate_cargo_nix(&mut temp_file)?;
 
-    temp_file
-        .persist(path)
-        .context(format!("could not write file to {}", path.display()))?;
+    if let Err(err) = temp_file.persist(path) {
+        let (_, temp_path) = err.file.keep()?;
+        std::fs::copy(temp_path, path)
+            .context(format!("could not write file to {}", path.display()))?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
### Fixed

* Attempt to copy tempfile if atomic rename fails.

This should fix cases where `tempfile::NamedTempFile::persist()` fails due to `Invalid cross-device link (os error 18)`, which is likely due to atomic file moves being problematic on Linux with `/tmp` on `tmpfs` or an otherwise separate filesystem from the root partition.

Would you mind trying this branch and confirm whether it fixes your issue, @vbrandl?

Fixes #97.