### PR TITLE
Remove implied packageOverrides from hello-world project

### DIFF
--- a/examples/1-hello-world/default.nix
+++ b/examples/1-hello-world/default.nix
@@ -21,7 +21,6 @@ let
   rustPkgs = pkgs.rustBuilder.makePackageSet' {
     rustChannel = "stable";
     packageFun = import ./Cargo.nix;
-    packageOverrides = pkgs: pkgs.rustBuilder.overrides.all;
   };
 in
   rustPkgs.workspace.hello-world {}


### PR DESCRIPTION
### Removed

* Remove implied `packageOverrides` from `hello-world` project. We leave the commented form in the `bigger-project` example for demonstration purposes.

This value is implied if unspecified by the user, and it should've been removed in #95.