### PR TITLE
Remove pkg-config nativeBuildInput in mkCrate

### DIFF
--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -97,7 +97,7 @@ let
     inherit src version meta;
     buildInputs = runtimeDependencies;
     propagatedBuildInputs = concatMap (drv: drv.propagatedBuildInputs) runtimeDependencies;
-    nativeBuildInputs = [ cargo buildPackages.pkg-config ] ++ buildtimeDependencies;
+    nativeBuildInputs = [ cargo ] ++ buildtimeDependencies;
 
     depsBuildBuild =
       let inherit (buildPackages.buildPackages) stdenv jq remarshal;

--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -131,6 +131,9 @@ in rec {
             { name = "PKG_CONFIG_ALLOW_CROSS"; value = "1"; }
           ])
         ];
+        propagatedNativeBuildInputs = drv.propagatedNativeBuildInputs or [ ] ++ [
+          pkgs.buildPackages.pkg-config
+        ];
       };
     }
     else nullOverride;


### PR DESCRIPTION
### Added

* Add `buildPackages.pkg-config` as propagated native build input to `pkg-config` override.

### Removed

* Remove `pkg-config` native build input for `mkCrate`.

I don't really think it makes sense to have `pkg-config` as a required native build input for `mkCrate` but not any other meta-packaging or meta-compilation tool, for example. Instead, we should add `pkg-config` to the `pkg-config` crate override in `overlay/overrides.nix`. This way, crates that require it will have access to it, while all others that don't will avoid pulling it in unnecessarily.

I've tried rebuilding `cargo2nix` itself (which depends on `pkg-config` for a few dependencies) as well as larger crates such as `rust-analyzer` without any apparent issues. I'd appreciate a second or third pair of eyes to confirm that this change doesn't break anything. 😄 