### PR TITLE
Update fetchGit

### DIFF
--- a/overlay/lib/fetch.nix
+++ b/overlay/lib/fetch.nix
@@ -8,10 +8,10 @@ rec {
 
   fetchCrateGit = { url, name, version, rev, sha256 }:
     let
-      inherit (buildPackages) runCommand jq remarshal fetchgitPrivate;
-      repo = fetchgitPrivate {
+      inherit (buildPackages) runCommand jq remarshal;
+      repo = builtins.fetchGit {
         name = "${name}-${version}-src";
-        inherit url rev sha256;
+        inherit url rev;
       };
     in
       /. + builtins.readFile (runCommand "find-crate-${name}-${version}"
@@ -35,7 +35,7 @@ rec {
   fetchCrateAlternativeRegistryExpensive = { index, name, version, sha256 }: with buildPackages; stdenvNoCC.mkDerivation {
     name = "${name}-${version}.tar.gz";
 
-    inherit (fetchgitPrivate { url = git://dummy; }) GIT_SSH SSH_AUTH_SOCK;
+    inherit (builtins.fetchGit { url = git://dummy; }) GIT_SSH SSH_AUTH_SOCK;
     INDEX = index;
     CRATE_NAME = name;
     CRATE_VERSION = version;

--- a/templates/Cargo.nix.tera
+++ b/templates/Cargo.nix.tera
@@ -51,7 +51,7 @@ in
       name = "{{ crate.name }}";
       version = "{{ crate.version }}";
       rev = "{{ crate.source.Git.rev }}";
-      sha256 = "{{ crate.source.Git.sha256 }}";
+      sha256 = "{{ crate.source.Git.sha256 }}"; {# unused #}
     };
     {%- elif crate.source.Local.path %}
     src = fetchCrateLocal ./{{ crate.source.Local.path }};


### PR DESCRIPTION
fetchgitPrivate was deprecated in nixpkgs master.

This change drops support for sha256 integrity checking for git dependencies.
The unused sha256 is noted in the Cargo.nix generation template.  The integrity
check is only relevant to fetchCrateGit.

* Template change was tested by re-generating a Cargo.nix with git deps
* Overlay change was tested by patching the overlay to build a project with git deps
* Changes to `fetchCrateAlternativeRegistryExpensive` have not been tested but are broken as is

Fixes #108 