### PR TITLE
Move user overlays to tail

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -20,7 +20,7 @@ let
         rustOverlay = import "${nixpkgsMozilla}/rust-overlay.nix";
         cargo2nixOverlay = import ./overlay;
       in
-        overlays ++ [ cargo2nixOverlay rustOverlay ];
+        [ cargo2nixOverlay rustOverlay ] ++ overlays;
   };
 
   # 2. Builds the rust package set, which contains all crates in your cargo workspace's dependency graph.


### PR DESCRIPTION
Almost anything the user overlays would be intended to fix will require being
the last overlay in the chain.  It's impossible to modify Rust dependencies in
the first overlay position without even more clever hacks to the mozilla or
cargo2nix overlays.

Change developed originally here:
https://github.com/tenx-tech/cargo2nix/commit/885488ed0a2431c19d5dca3c9a015ffb16b0f3ee#diff-5712e736e0de6ba170577f8472c398e9R23