### PR TITLE
Update to builtins.fetchGit

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ runHook runCargo
    error: while parsing a TOML string at /nix/store/.../overlay/mkcrate.nix:31:14: Bare key 'cfg(target_os = "linux")' cannot contain whitespace at line 45
    ```
 
+3. Git dependencies and crates from alternative Cargo registries rely on
+   `builtins.fetchGit` to support fetching from private Git repositories. This
+   means that such dependencies cannot be evaluated with `restrict-eval`
+   applied.
+
 ## Design
 
 This Nixpkgs overlay builds your Rust crates and binaries by first pulling the

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ runHook runCargo
 1. Many `crates.io` public crates may not build using the current Rust compiler,
    unless a lint cap is put on these crates. For instance, `cargo2nix` caps all
    lints to `warn` by default.
+
 2. Nix 2.1.3 ships with a broken `builtins.fromTOML` function which is unable to
    parse lines of TOML that look like this:
 
@@ -113,6 +114,10 @@ runHook runCargo
    `builtins.fetchGit` to support fetching from private Git repositories. This
    means that such dependencies cannot be evaluated with `restrict-eval`
    applied.
+
+   Also, if your Git dependency is tied to a Git branch, e.g. `master`, and you
+   would like to force it to update on upstream changes, you should append
+   `--option tarball-ttl 0` to your `nix-build` command.
 
 ## Design
 

--- a/overlay/lib/fetch.nix
+++ b/overlay/lib/fetch.nix
@@ -34,9 +34,8 @@ rec {
   # to be downloaded, the whole index needs to be recloned to get the download URL, which is potentially expensive.
   fetchCrateAlternativeRegistryExpensive = { index, name, version, sha256 }: with buildPackages; stdenvNoCC.mkDerivation {
     name = "${name}-${version}.tar.gz";
+    src = builtins.fetchGit { url = index; ref = "master"; };
 
-    inherit (builtins.fetchGit { url = git://dummy; }) GIT_SSH SSH_AUTH_SOCK;
-    INDEX = index;
     CRATE_NAME = name;
     CRATE_VERSION = version;
 
@@ -44,12 +43,11 @@ rec {
     outputHashMode = "flat";
     outputHash = sha256;
 
-    nativeBuildInputs = [ git curl cacert jq ];
+    nativeBuildInputs = [ curl cacert jq ];
 
     builder = builtins.toFile "builder.sh" ''
       source "$stdenv/setup"
-      git clone --depth=1 "$INDEX" ./index
-      dl="$(jq -r ".dl" ./index/config.json)"
+      dl="$(jq -r ".dl" "$src/config.json")"
       if [[ "$dl" =~ "{crate}" ]]; then
         url="$(sed -e "s/{crate}/$CRATE_NAME/" -e "s/{version}/$CRATE_VERSION/" <<< "$dl")"
       else

--- a/overlay/lib/fetch.nix
+++ b/overlay/lib/fetch.nix
@@ -8,10 +8,10 @@ rec {
 
   fetchCrateGit = { url, name, version, rev, sha256 }:
     let
-      inherit (buildPackages) runCommand jq remarshal fetchgitPrivate;
-      repo = fetchgitPrivate {
+      inherit (buildPackages) runCommand jq remarshal;
+      repo = builtins.fetchGit {
         name = "${name}-${version}-src";
-        inherit url rev sha256;
+        inherit url rev;
       };
     in
       /. + builtins.readFile (runCommand "find-crate-${name}-${version}"
@@ -35,7 +35,7 @@ rec {
   fetchCrateAlternativeRegistryExpensive = { index, name, version, sha256 }: with buildPackages; stdenvNoCC.mkDerivation {
     name = "${name}-${version}.tar.gz";
 
-    inherit (fetchgitPrivate { url = git://dummy; }) GIT_SSH SSH_AUTH_SOCK;
+    inherit (builtins.fetchGit { url = git://dummy; }) GIT_SSH SSH_AUTH_SOCK;
     INDEX = index;
     CRATE_NAME = name;
     CRATE_VERSION = version;

--- a/templates/Cargo.nix.tera
+++ b/templates/Cargo.nix.tera
@@ -51,7 +51,7 @@ in
       name = "{{ crate.name }}";
       version = "{{ crate.version }}";
       rev = "{{ crate.source.Git.rev }}";
-      sha256 = "{{ crate.source.Git.sha256 }}";
+      sha256 = "{{ crate.source.Git.sha256 }}"; {# unused #}
     };
     {%- elif crate.source.Local.path %}
     src = fetchCrateLocal ./{{ crate.source.Local.path }};


### PR DESCRIPTION
### Added

* Add notice regarding caveats of `builtins.fetchGit` to `README.md`.
### Changed

* Switch from `fetchgitPrivate` (which was removed upstream) to `builtins.fetchGit`.
* Ignore the `sha256` argument used in `fetchCrateGit` for backwards compatibility. We should remove this argument from the overlay and codegen completely in a subsequent minor release.

Original commit authored by @macs-overdrv and cherry-picked from #109. CC @Mic92

Fixes #108.