### PR TITLE
Fix pkg-config override, indirectly fixing curl-sys

### DIFF
--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -127,11 +127,11 @@ in rec {
     overrideAttrs = drv: {
       propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [
         pkgs.pkg-config
-      ] ++ lib.optional (pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform) [
+      ] ++ lib.optional (pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform)
         (propagateEnv "pkg-config" [
           { name = "PKG_CONFIG_ALLOW_CROSS"; value = "1"; }
         ])
-      ];
+      ;
     };
   };
 

--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -127,11 +127,10 @@ in rec {
     overrideAttrs = drv: {
       propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [
         pkgs.pkg-config
-      ] ++ lib.optional (pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform)
         (propagateEnv "pkg-config" [
           { name = "PKG_CONFIG_ALLOW_CROSS"; value = "1"; }
         ])
-      ;
+      ];
     };
   };
 

--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -130,8 +130,6 @@ in rec {
           (propagateEnv "pkg-config" [
             { name = "PKG_CONFIG_ALLOW_CROSS"; value = "1"; }
           ])
-        ];
-        propagatedNativeBuildInputs = drv.propagatedNativeBuildInputs or [ ] ++ [
           pkgs.buildPackages.pkg-config
         ];
       };

--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -122,19 +122,18 @@ in rec {
     };
   };
 
-  pkg-config = if pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform
-    then makeOverride {
-      name = "pkg-config";
-      overrideAttrs = drv: {
-        propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [
-          (propagateEnv "pkg-config" [
-            { name = "PKG_CONFIG_ALLOW_CROSS"; value = "1"; }
-          ])
-          pkgs.buildPackages.pkg-config
-        ];
-      };
-    }
-    else nullOverride;
+  pkg-config = makeOverride {
+    name = "pkg-config";
+    overrideAttrs = drv: {
+      propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [
+        pkgs.pkg-config
+      ] ++ lib.optional (pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform) [
+        (propagateEnv "pkg-config" [
+          { name = "PKG_CONFIG_ALLOW_CROSS"; value = "1"; }
+        ])
+      ];
+    };
+  };
 
   pq-sys =
     let


### PR DESCRIPTION
### Changed

* Use `pkgs.pkg-config` over `pkgs.buildPackages.pkg-config`.
* Pass `pkgs.pkg-config` to `propagatedBuildInputs` instead of `propagatedNativeBuildInputs`.

### Fixed

* Always include `pkgs.pkg-config` as a propagated build input in the crate override, regardless of whether we are cross-compiling or not, fixing a bug introduced in #104.