### PR TITLE
Remove empty link-flags files

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -78,7 +78,7 @@ rec {
   # `cargo build` with in the shell should just work.
   shell = pkgs.mkShell {
     inputsFrom = pkgs.lib.mapAttrsToList (_: pkg: pkg { }) rustPkgs.noBuild.workspace;
-    nativeBuildInputs = with rustPkgs; [ cargo rustc ];
+    nativeBuildInputs = with rustPkgs; [ cargo rustc rust-src ];
   };
   examples =
     let

--- a/overlay/make-package-set/full.nix
+++ b/overlay/make-package-set/full.nix
@@ -11,6 +11,7 @@
   packageFun,
   cargo,
   rustc,
+  rust-src,
   buildRustPackages ? null,
   localPatterns ? [ ''^(src|tests)(/.*)?'' ''[^/]*\.(rs|toml)$'' ],
   packageOverrides ? rustBuilder.overrides.all,
@@ -55,7 +56,7 @@ lib.fix' (self:
     });
 
   in packageFunWith { mkRustCrate = mkRustCrate'; buildRustPackages = buildRustPackages'; } // {
-    inherit rustPackages callPackage cargo rustc pkgs;
+    inherit rustPackages callPackage cargo rustc rust-src pkgs;
     noBuild = packageFunWith {
       mkRustCrate = lib.makeOverridable mkRustCrateNoBuild { };
       buildRustPackages = buildRustPackages'.noBuild;

--- a/overlay/make-package-set/simplified.nix
+++ b/overlay/make-package-set/simplified.nix
@@ -14,7 +14,7 @@ let
   rustChannel = buildPackages.rustChannelOf {
     channel = args.rustChannel;
   };
-  inherit (rustChannel) cargo;
+  inherit (rustChannel) cargo rust-src;
   rustc = rustChannel.rust.override {
     targets = [
       (rustBuilder.rustLib.realHostTriple stdenv.targetPlatform)
@@ -23,10 +23,10 @@ let
   extraArgs = builtins.removeAttrs args [ "rustChannel" "packageFun" "packageOverrides" ];
 in
 rustBuilder.makePackageSet (extraArgs // {
-  inherit cargo rustc packageFun;
+  inherit cargo rustc rust-src packageFun;
   packageOverrides = packageOverrides pkgs;
   buildRustPackages = buildPackages.rustBuilder.makePackageSet (extraArgs // {
-    inherit cargo rustc packageFun;
+    inherit cargo rustc rust-src packageFun;
     packageOverrides = packageOverrides buildPackages;
   });
 })

--- a/overlay/utils.sh
+++ b/overlay/utils.sh
@@ -156,6 +156,9 @@ install_crate() {
 
     touch $out/lib/.link-flags
     loadExternCrateLinkFlags $dependencies >> $out/lib/.link-flags
+    if [ ! -s $out/lib/.link-flags ]; then
+      rm $out/lib/.link-flags
+    fi
 
     if [ "$isProcMacro" ]; then
         pushd target/release


### PR DESCRIPTION
Background is that when certain programs (home manager) are building a profile
to activate, these ./link-flags files are going to collide even though they
don't end up in the user's profile.  While this may be a buggy home manager
behavior, it would also be better not to have unnecessary outputs.

A proper fix needs to start by asking what these files are used for after
building the current crate and its dependents.  This file does not appear to
serve any standard role outside of the cargo2nix context and some of the
contents may be extraneous.

The derivation for cargo2nix will output a .link-flags with flags inside in an
otherwise empty lib folder while rust-analyzer with a busy lib folder has an
empty .link-flags

With the current home manager behavior, any two cargo2nix projects that leave
behind these identically named files will collide.  Even if empty ./link-flags
and ./link-flags with no rlib associations are removed, two cargo2nix
derivations that link to native libraries and have rlib outputs are enough to
trigger the collision.