### PR TITLE
Add protobuf to protoc in override

### DIFF
--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -70,6 +70,7 @@ in rec {
     pkg-config
     pq-sys
     prost-build
+    protoc
     rand
     rand_os
     rdkafka-sys
@@ -160,6 +161,13 @@ in rec {
           { name = "PROTOC"; value = "${pkgs.buildPackages.buildPackages.protobuf}/bin/protoc"; }
         ])
       ];
+    };
+  };
+
+  protoc = makeOverride {
+    name = "protoc";
+    overrideAttrs = drv: {
+      propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [ pkgs.buildPackages.buildPackages.protobuf ];
     };
   };
 


### PR DESCRIPTION
When I use [protoc-rust-grpc](https://crates.io/crates/protoc-rust-grpc) crate which uses [protoc](https://crates.io/crates/protoc) crate internally, I get an error due to `protoc` file not being found.

```
--- stderr
thread 'main' panicked at 'protoc version: Custom { kind: NotFound, error: "failed to spawn `\"protoc\" \"--version\"`: No such file or directory (os error 2)" }', src/lib.rs:97:23
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This override for [protoc](https://crates.io/crates/protoc) crate seems to help with that.