### PR TITLE
Prepare release 0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "cargo2nix"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "cargo 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo-platform 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -27,7 +27,7 @@ in
 {
   cargo2nixVersion = "0.8.2";
   workspace = {
-    cargo2nix = rustPackages.unknown.cargo2nix."0.8.2";
+    cargo2nix = rustPackages.unknown.cargo2nix."0.8.3";
   };
   "registry+https://github.com/rust-lang/crates.io-index".adler32."1.0.4" = overridableMkRustCrate (profileName: rec {
     name = "adler32";
@@ -266,9 +266,9 @@ in
     };
   });
   
-  "unknown".cargo2nix."0.8.2" = overridableMkRustCrate (profileName: rec {
+  "unknown".cargo2nix."0.8.3" = overridableMkRustCrate (profileName: rec {
     name = "cargo2nix";
-    version = "0.8.2";
+    version = "0.8.3";
     registry = "unknown";
     src = fetchCrateLocal ./.;
     dependencies = {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo2nix"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2018"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ you into such a development shell.
 ```bash
 # When a crate is not associated with any registry, such as when building locally,
 # the registry is "unknown" as shown below.
-nix-shell -A 'rustPkgs.unknown.cargo2nix."0.8.0"' default.nix
+nix-shell -A 'rustPkgs.unknown.cargo2nix."0.8.3"' default.nix
 ```
 
 You will need to bootstrap some environment in this declarative development


### PR DESCRIPTION
### Changed

* Bump `cargo2nix` crate version to 0.8.3 and regenerate `Cargo.nix`.
* Update outdated example in `README.md`.

Since this version of the `Cargo.nix` format is backwards-compatible with the current release, and all manner of changes merged since then have been either forward-compatible bugfixes or minor additions to the overlay, I believe a patch release of 0.8.3 is sufficient here. I'll prepare a new GitHub release changelog immediately after this gets merged.

CC @edude03