### PR TITLE
Use --message-format=json to install artifacts

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -52,7 +52,7 @@ let
   #     e.g. `[ "aes" "sse2" "ssse3" "sse4.1" ]`.  They will be prefixed with a "+", and comma delimited before passing through to rust.
   #     Crates that check for CPU features such as the `aes` crate will be evaluated against this argument.
   rustPkgs = pkgs.rustBuilder.makePackageSet' {
-    rustChannel = "1.37.0";
+    rustChannel = "1.41.0";
     packageFun = import ./Cargo.nix;
     packageOverrides = pkgs: pkgs.rustBuilder.overrides.all;
     localPatterns = [ ''^(src|tests|templates)(/.*)?'' ''[^/]*\.(rs|toml)$'' ];

--- a/default.nix
+++ b/default.nix
@@ -52,7 +52,7 @@ let
   #     e.g. `[ "aes" "sse2" "ssse3" "sse4.1" ]`.  They will be prefixed with a "+", and comma delimited before passing through to rust.
   #     Crates that check for CPU features such as the `aes` crate will be evaluated against this argument.
   rustPkgs = pkgs.rustBuilder.makePackageSet' {
-    rustChannel = "1.41.0";
+    rustChannel = "1.37.0";
     packageFun = import ./Cargo.nix;
     packageOverrides = pkgs: pkgs.rustBuilder.overrides.all;
     localPatterns = [ ''^(src|tests|templates)(/.*)?'' ''[^/]*\.(rs|toml)$'' ];

--- a/default.nix
+++ b/default.nix
@@ -84,10 +84,17 @@ rec {
   };
   examples =
     let
+      cargo2nix = pkgs.lib.sourceByRegex ./. [
+        ''^(overlay|src|tests|templates)(/.*)?''
+        ''[^/]*\.(nix|rs|toml)$''
+      ];
       importExprsInDir = with pkgs.lib; dir:
-        mapAttrsToList (name: _: import (dir + "/${name}") {})
-          (pkgs.lib.filterAttrs (name: kind: kind == "directory")
-            (builtins.readDir dir));
+        mapAttrsToList
+          (name: _: import (dir + "/${name}") { inherit cargo2nix; })
+          (pkgs.lib.filterAttrs
+            (name: kind: kind == "directory")
+            (builtins.readDir dir)
+          );
     in
       importExprsInDir ./examples;
 }

--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -148,6 +148,12 @@ let
       EOF
     '';
 
+    configurePhase = ''
+      runHook preConfigure
+      runHook configureCargo
+      runHook postConfigure
+    '';
+
     manifestPatch = toJSON {
       features = genAttrs features (_: [ ]);
       profile.${ decideProfile compileMode release } = profile;
@@ -169,13 +175,6 @@ let
               } + $manifestPatch" \
         | remarshal -if json -of toml > Cargo.toml
     '';
-
-    configurePhase =
-      ''
-        runHook preConfigure
-        runHook configureCargo
-        runHook postConfigure
-      '';
 
     runCargo = ''
       (

--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -176,22 +176,6 @@ let
         | remarshal -if json -of toml > Cargo.toml
     '';
 
-    runCargo = ''
-      (
-        set -euo pipefail
-        if (( NIX_DEBUG >= 1 )); then
-          set -x
-        fi
-        env \
-          "CC_${stdenv.buildPlatform.config}"="${ccForBuild}" \
-          "CXX_${stdenv.buildPlatform.config}"="${cxxForBuild}" \
-          "CC_${host-triple}"="${ccForHost}" \
-          "CXX_${host-triple}"="${cxxForHost}" \
-          "''${depKeys[@]}" \
-          ${buildCmd}
-      )
-    '';
-
     setBuildEnv = ''
       MINOR_RUSTC_VERSION="$(${rustc}/bin/rustc --version | cut -d . -f 2)"
 
@@ -233,6 +217,22 @@ let
           echo $key
         done
       fi
+    '';
+
+    runCargo = ''
+      (
+        set -euo pipefail
+        if (( NIX_DEBUG >= 1 )); then
+          set -x
+        fi
+        env \
+          "CC_${stdenv.buildPlatform.config}"="${ccForBuild}" \
+          "CXX_${stdenv.buildPlatform.config}"="${cxxForBuild}" \
+          "CC_${host-triple}"="${ccForHost}" \
+          "CXX_${host-triple}"="${cxxForHost}" \
+          "''${depKeys[@]}" \
+          ${buildCmd}
+      )
     '';
 
     buildPhase = ''

--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -95,9 +95,8 @@ let
     runtimeDependencies buildtimeDependencies;
 
   drvAttrs = {
-    inherit NIX_DEBUG;
+    inherit src version meta NIX_DEBUG;
     name = "crate-${name}-${version}${optionalString (compileMode != "build") "-${compileMode}"}";
-    inherit src version meta;
     buildInputs = runtimeDependencies;
     propagatedBuildInputs = concatMap (drv: drv.propagatedBuildInputs) runtimeDependencies;
     nativeBuildInputs = [ cargo ] ++ buildtimeDependencies;

--- a/overlay/utils.sh
+++ b/overlay/utils.sh
@@ -1,278 +1,278 @@
 # shellcheck shell=bash
 
 extractFileExt() {
-    local name=$(basename "$1")
-    echo "${name##*.}"
+  local name=$(basename "$1")
+  echo "${name##*.}"
 }
 
 extractHash() {
-    local name=$(basename "$1")
-    echo "${name%%-*}"
+  local name=$(basename "$1")
+  echo "${name%%-*}"
 }
 
 makeExternCrateFlags() {
-    for (( i=1; i<$#; i+=2 )); do
-        local extern_name="${@:$i:1}"
-        local crate="${@:((i+1)):1}"
-        [ -f "$crate/.cargo-info" ] || continue
+  for (( i=1; i<$#; i+=2 )); do
+    local extern_name="${@:$i:1}"
+    local crate="${@:((i+1)):1}"
+    [ -f "$crate/.cargo-info" ] || continue
 
-        local crate_name=$(jq -r '.name' "$crate/.cargo-info")
-        local proc_macro=$(jq -r '.proc_macro' "$crate/.cargo-info")
+    local crate_name=$(jq -r '.name' "$crate/.cargo-info")
+    local proc_macro=$(jq -r '.proc_macro' "$crate/.cargo-info")
 
-        if [ "$proc_macro" ]; then
-            echo "--extern" "${extern_name}=$crate/lib/$proc_macro"
-        elif [ -f "$crate/lib/lib${crate_name}.rlib" ]; then
-            echo "--extern" "${extern_name}=$crate/lib/lib${crate_name}.rlib"
-        elif [ -f "$crate/lib/lib${crate_name}.so" ]; then
-            echo "--extern" "${extern_name}=$crate/lib/lib${crate_name}.so"
-        elif [ -f "$crate/lib/lib${crate_name}.a" ]; then
-            echo "--extern" "${extern_name}=$crate/lib/lib${crate_name}.a"
-        elif [ -f "$crate/lib/lib${crate_name}.dylib" ]; then
-            echo "--extern" "${extern_name}=$crate/lib/lib${crate_name}.dylib"
-        else
-            echo "do not know how to find $extern_name ($crate_name)" >&2
-            exit 1
-        fi
+    if [ "$proc_macro" ]; then
+      echo "--extern" "${extern_name}=$crate/lib/$proc_macro"
+    elif [ -f "$crate/lib/lib${crate_name}.rlib" ]; then
+      echo "--extern" "${extern_name}=$crate/lib/lib${crate_name}.rlib"
+    elif [ -f "$crate/lib/lib${crate_name}.so" ]; then
+      echo "--extern" "${extern_name}=$crate/lib/lib${crate_name}.so"
+    elif [ -f "$crate/lib/lib${crate_name}.a" ]; then
+      echo "--extern" "${extern_name}=$crate/lib/lib${crate_name}.a"
+    elif [ -f "$crate/lib/lib${crate_name}.dylib" ]; then
+      echo "--extern" "${extern_name}=$crate/lib/lib${crate_name}.dylib"
+    else
+      echo "do not know how to find $extern_name ($crate_name)" >&2
+      exit 1
+    fi
 
-        echo "-L dependency=$crate/lib/deps"
-        if [ -f "$crate/lib/.link-flags" ]; then
-            cat "$crate/lib/.link-flags"
-        fi
-    done
+    echo "-L dependency=$crate/lib/deps"
+    if [ -f "$crate/lib/.link-flags" ]; then
+      cat "$crate/lib/.link-flags"
+    fi
+  done
 }
 
 loadExternCrateLinkFlags() {
     for (( i=1; i<$#; i+=2 )); do
-        local extern_name="${@:$i:1}"
-        local crate="${@:((i+1)):1}"
-        [ -f "$crate/.cargo-info" ] || continue
+      local extern_name="${@:$i:1}"
+      local crate="${@:((i+1)):1}"
+      [ -f "$crate/.cargo-info" ] || continue
 
-        local crate_name=$(jq -r '.name' "$crate/.cargo-info")
-        if [ -f "$crate/lib/.link-flags" ]; then
-            cat "$crate/lib/.link-flags"
-        fi
+      local crate_name=$(jq -r '.name' "$crate/.cargo-info")
+      if [ -f "$crate/lib/.link-flags" ]; then
+        cat "$crate/lib/.link-flags"
+      fi
     done
 }
 
 loadDepKeys() {
-    for (( i=2; i<=$#; i+=2 )); do
-        local crate="${@:$i:1}"
-        [ -f "$crate/.cargo-info" ] && [ -f "$crate/lib/.dep-keys" ] || continue
-        cat "$crate/lib/.dep-keys"
-    done
+  for (( i=2; i<=$#; i+=2 )); do
+    local crate="${@:$i:1}"
+    [ -f "$crate/.cargo-info" ] && [ -f "$crate/lib/.dep-keys" ] || continue
+    cat "$crate/lib/.dep-keys"
+  done
 }
 
 linkExternCrateToDeps() {
-    local deps_dir=$1; shift
-    for (( i=1; i<$#; i+=2 )); do
-        local dep="${@:((i+1)):1}"
-        [ -f "$dep/.cargo-info" ] || continue
+  local deps_dir=$1; shift
+  for (( i=1; i<$#; i+=2 )); do
+    local dep="${@:((i+1)):1}"
+    [ -f "$dep/.cargo-info" ] || continue
 
-        local crate_name=$(jq -r '.name' "$dep/.cargo-info")
-        local metadata=$(jq -r '.metadata' "$dep/.cargo-info")
-        local proc_macro=$(jq -r '.proc_macro' "$dep/.cargo-info")
+    local crate_name=$(jq -r '.name' "$dep/.cargo-info")
+    local metadata=$(jq -r '.metadata' "$dep/.cargo-info")
+    local proc_macro=$(jq -r '.proc_macro' "$dep/.cargo-info")
 
-        if [ "$proc_macro" ]; then
-            local ext=$(extractFileExt "$proc_macro")
-            ln -sf "$dep/lib/$proc_macro" "$deps_dir/$(basename "$proc_macro.$ext")-$metadata.$ext"
-        else
-            ln -sf "$dep/lib/lib${crate_name}.rlib" "$deps_dir/lib${crate_name}-${metadata}.rlib"
-        fi
+    if [ "$proc_macro" ]; then
+      local ext=$(extractFileExt "$proc_macro")
+      ln -sf "$dep/lib/$proc_macro" "$deps_dir/$(basename "$proc_macro.$ext")-$metadata.$ext"
+    else
+      ln -sf "$dep/lib/lib${crate_name}.rlib" "$deps_dir/lib${crate_name}-${metadata}.rlib"
+    fi
 
-        (
-            shopt -s nullglob
-            for subdep in "$dep/lib/deps"/*; do
-                local subdep_name=$(basename "$subdep")
-                ln -sf "$subdep" "$deps_dir/$subdep_name"
-            done
-        )
-    done
+    (
+      shopt -s nullglob
+      for subdep in "$dep/lib/deps"/*; do
+        local subdep_name=$(basename "$subdep")
+        ln -sf "$subdep" "$deps_dir/$subdep_name"
+      done
+    )
+  done
 }
 
 upper() {
-    echo "${1^^}"
+  echo "${1^^}"
 }
 
 dumpDepInfo() {
-    local link_flags="$1"; shift
-    local dep_keys="$1"; shift
-    local cargo_links="$1"; shift
-    local dep_files="$1"; shift
-    local depinfo="$1"; shift
+  local link_flags="$1"; shift
+  local dep_keys="$1"; shift
+  local cargo_links="$1"; shift
+  local dep_files="$1"; shift
+  local depinfo="$1"; shift
 
-    while read line; do
-        [[ "x$line" =~ xcargo:([^=]+)=(.*) ]] || continue
-        local key="${BASH_REMATCH[1]}"
-        local val="${BASH_REMATCH[2]}"
+  while read line; do
+    [[ "x$line" =~ xcargo:([^=]+)=(.*) ]] || continue
+    local key="${BASH_REMATCH[1]}"
+    local val="${BASH_REMATCH[2]}"
 
-        case $key in
-            rustc-link-lib) ;&
-            rustc-flags) ;&
-            rustc-cfg) ;&
-            rustc-env) ;&
-            rerun-if-changed) ;&
-            rerun-if-env-changed) ;&
-            warning)
-            ;;
-            rustc-link-search)
-                echo "-L $(printf '%q' "$val")" >> "$link_flags"
-                ;;
-            *)
-                if [ -e "$val" ]; then
-                    local dep_file_target="$dep_files/DEP_$(upper "$cargo_links")_$(upper "$key")"
-                    cp -r "$val" "$dep_file_target"
-                    val=$dep_file_target
-                fi
-                printf 'DEP_%s_%s=%s\n' "$(upper "$cargo_links")" "$(upper "$key")" "$val" >> "$dep_keys"
-        esac
-    done < "$depinfo"
+    case $key in
+      rustc-link-lib) ;&
+      rustc-flags) ;&
+      rustc-cfg) ;&
+      rustc-env) ;&
+      rerun-if-changed) ;&
+      rerun-if-env-changed) ;&
+      warning)
+      ;;
+      rustc-link-search)
+        echo "-L $(printf '%q' "$val")" >> "$link_flags"
+        ;;
+      *)
+        if [ -e "$val" ]; then
+          local dep_file_target="$dep_files/DEP_$(upper "$cargo_links")_$(upper "$key")"
+          cp -r "$val" "$dep_file_target"
+          val=$dep_file_target
+        fi
+        printf 'DEP_%s_%s=%s\n' "$(upper "$cargo_links")" "$(upper "$key")" "$val" >> "$dep_keys"
+    esac
+  done < "$depinfo"
 }
 
 install_crate2() {
-    mkdir -p "$out/lib"
-    # shellcheck disable=SC2046
-    cp $(jq -rR 'fromjson?
-        | select(.reason == "compiler-artifact")
-        | .filenames
-        | map(select(test("\\.(a|rlib|so|dylib)$")))
-        | .[]' < .cargo-build-output) "$out/lib" 2> /dev/null || :
+  mkdir -p "$out/lib"
+  # shellcheck disable=SC2046
+  cp $(jq -rR 'fromjson?
+    | select(.reason == "compiler-artifact")
+    | .filenames
+    | map(select(test("\\.(a|rlib|so|dylib)$")))
+    | .[]' < .cargo-build-output) "$out/lib" 2> /dev/null || :
 
-    jq -rR 'fromjson?
-        | select(.reason == "build-script-executed")
-        | (.linked_libs | map("-l \(.)")) + (.linked_paths | map("-L \(.)"))
-        | .[]' < .cargo-build-output \
-        | tr '\n' ' ' >> "$out/lib/.link-flags"
+  jq -rR 'fromjson?
+    | select(.reason == "build-script-executed")
+    | (.linked_libs | map("-l \(.)")) + (.linked_paths | map("-L \(.)"))
+    | .[]' < .cargo-build-output \
+    | tr '\n' ' ' >> "$out/lib/.link-flags"
 
-    mkdir -p "$out/bin"
-    # shellcheck disable=SC2046
-    cp $(jq -rR 'fromjson?
-        | select(.reason == "compiler-artifact")
-        | .executable
-        | select(.)' < .cargo-build-output) "$out/bin" 2> /dev/null || rmdir "$out/bin"
+  mkdir -p "$out/bin"
+  # shellcheck disable=SC2046
+  cp $(jq -rR 'fromjson?
+    | select(.reason == "compiler-artifact")
+    | .executable
+    | select(.)' < .cargo-build-output) "$out/bin" 2> /dev/null || rmdir "$out/bin"
 
-    local out_dir
-    if out_dir="$(jq -rR 'fromjson? | select(.reason == "build-script-executed") | .out_dir' < .cargo-build-output)"; then
-        touch "$out/lib/.dep-keys"
+  local out_dir
+  if out_dir="$(jq -rR 'fromjson? | select(.reason == "build-script-executed") | .out_dir' < .cargo-build-output)"; then
+    touch "$out/lib/.dep-keys"
 
-        # `links` envs aren't included in build output so we have to manually parse them.
-        if [[ -f "$out_dir/../output" ]]; then
-            grep -P '^cargo:(?!rerun-if-changed|rerun-if-env-changed|rustc-link-lib|rustc-link-search|rustc-flags|rustc-cfg|rustc-env|rustc-cdylib-link-arg|warning)' \
-                "$out_dir/../output" | while IFS= read -r line; do
-                [[ "$line" =~ cargo:([^=]+)=(.*) ]] || continue
-                local key="${BASH_REMATCH[1]}"
-                local val="${BASH_REMATCH[2]}"
-                printf 'DEP_%s_%s=%s\n' "$(upper "$cargo_links")" "$(upper "$key")" "$val" >> "$out/lib/.dep-keys"
-            done || :
-        fi
-
-        if [[ -d "$out_dir" ]] && { grep "$out_dir" "$out/lib/.dep-keys" || grep "$out_dir" "$out/lib/.link-flags"; }; then
-            local installed_out_dir="$out/build_output" # TODO: Change me
-            sed -i "s#$out_dir#$installed_out_dir#g" "$out/lib/.dep-keys"
-            sed -i "s#$out_dir#$installed_out_dir#g" "$out/lib/.link-flags"
-            cp -r "$out_dir" "$installed_out_dir"
-        fi
+    # `links` envs aren't included in build output so we have to manually parse them.
+    if [[ -f "$out_dir/../output" ]]; then
+      grep -P '^cargo:(?!rerun-if-changed|rerun-if-env-changed|rustc-link-lib|rustc-link-search|rustc-flags|rustc-cfg|rustc-env|rustc-cdylib-link-arg|warning)' \
+        "$out_dir/../output" | while IFS= read -r line; do
+        [[ "$line" =~ cargo:([^=]+)=(.*) ]] || continue
+        local key="${BASH_REMATCH[1]}"
+        local val="${BASH_REMATCH[2]}"
+        printf 'DEP_%s_%s=%s\n' "$(upper "$cargo_links")" "$(upper "$key")" "$val" >> "$out/lib/.dep-keys"
+      done || :
     fi
 
-    loadExternCrateLinkFlags $dependencies >> "$out/lib/.link-flags"
-
-    if (shopt -s failglob; : "$out/lib"/*.rlib) 2> /dev/null; then
-        mkdir -p "$out/lib/deps"
-        linkExternCrateToDeps "$out/lib/deps" $dependencies
+    if [[ -d "$out_dir" ]] && { grep "$out_dir" "$out/lib/.dep-keys" || grep "$out_dir" "$out/lib/.link-flags"; }; then
+      local installed_out_dir="$out/build_output" # TODO: Change me
+      sed -i "s#$out_dir#$installed_out_dir#g" "$out/lib/.dep-keys"
+      sed -i "s#$out_dir#$installed_out_dir#g" "$out/lib/.link-flags"
+      cp -r "$out_dir" "$installed_out_dir"
     fi
+  fi
 
-    jq -n '{name:$name, metadata:$metadata, version:$version, proc_macro:$procmacro}' \
-        --arg name "$crateName" \
-        --arg metadata "$NIX_RUST_METADATA" \
-        --arg procmacro "$(basename "$(jq -rR 'fromjson? | select(.target.kind[0] == "proc-macro") | .filenames[0]' < .cargo-build-output)")" \
-        --arg version "$version" > "$out/.cargo-info"
+  loadExternCrateLinkFlags $dependencies >> "$out/lib/.link-flags"
+
+  if (shopt -s failglob; : "$out/lib"/*.rlib) 2> /dev/null; then
+    mkdir -p "$out/lib/deps"
+    linkExternCrateToDeps "$out/lib/deps" $dependencies
+  fi
+
+  jq -n '{name:$name, metadata:$metadata, version:$version, proc_macro:$procmacro}' \
+    --arg name "$crateName" \
+    --arg metadata "$NIX_RUST_METADATA" \
+    --arg procmacro "$(basename "$(jq -rR 'fromjson? | select(.target.kind[0] == "proc-macro") | .filenames[0]' < .cargo-build-output)")" \
+    --arg version "$version" > "$out/.cargo-info"
 }
 
 install_crate() {
-    local host_triple="$1"
-    local mode="$2"
-    pushd "target/${host_triple}/${mode}"
+  local host_triple="$1"
+  local mode="$2"
+  pushd "target/${host_triple}/${mode}"
 
-    local needs_deps=
-    local has_output=
+  local needs_deps=
+  local has_output=
+  for output in *; do
+    if [ -d "$output" ]; then
+      continue
+    elif [ -x "$output" ]; then
+      mkdir -p "$out/bin"
+      cp "$output" "$out/bin/"
+      has_output=1
+    else
+      case $(extractFileExt "$output") in
+        rlib)
+          mkdir -p "$out/lib/.dep-files"
+          cp "$output" "$out/lib/"
+
+          local link_flags="$out/lib/.link-flags"
+          local dep_keys="$out/lib/.dep-keys"
+          touch "$link_flags" "$dep_keys"
+
+          for depinfo in build/*/output; do
+            dumpDepInfo "$link_flags" "$dep_keys" "$cargo_links" "$out/lib/.dep-files" "$depinfo"
+          done
+
+          needs_deps=1
+          has_output=1
+          ;;
+        a) ;&
+        so) ;&
+        dylib)
+          mkdir -p "$out/lib"
+          cp "$output" "$out/lib/"
+          has_output=1
+          ;;
+        *)
+          continue
+      esac
+    fi
+  done
+  popd
+
+  touch "$out/lib/.link-flags"
+  loadExternCrateLinkFlags $dependencies >> "$out/lib/.link-flags"
+
+  if [ "$isProcMacro" ]; then
+    pushd "target/${mode}"
     for output in *; do
-        if [ -d "$output" ]; then
-            continue
-        elif [ -x "$output" ]; then
-            mkdir -p "$out/bin"
-            cp "$output" "$out/bin/"
-            has_output=1
-        else
-            case $(extractFileExt "$output") in
-                rlib)
-                    mkdir -p "$out/lib/.dep-files"
-                    cp "$output" "$out/lib/"
-
-                    local link_flags="$out/lib/.link-flags"
-                    local dep_keys="$out/lib/.dep-keys"
-                    touch "$link_flags" "$dep_keys"
-
-                    for depinfo in build/*/output; do
-                        dumpDepInfo "$link_flags" "$dep_keys" "$cargo_links" "$out/lib/.dep-files" "$depinfo"
-                    done
-
-                    needs_deps=1
-                    has_output=1
-                    ;;
-                a) ;&
-                so) ;&
-                dylib)
-                    mkdir -p "$out/lib"
-                    cp "$output" "$out/lib/"
-                    has_output=1
-                    ;;
-                *)
-                    continue
-            esac
-        fi
+      if [ -d "$output" ]; then
+        continue
+      fi
+      case $(extractFileExt "$output") in
+        so) ;&
+        dylib)
+          isProcMacro=$(basename "$output")
+          mkdir -p "$out/lib"
+          cp "$output" "$out/lib"
+          needs_deps=1
+          has_output=1
+          ;;
+        *)
+          continue
+      esac
     done
     popd
+  fi
 
-    touch "$out/lib/.link-flags"
-    loadExternCrateLinkFlags $dependencies >> "$out/lib/.link-flags"
+  if [ ! "$has_output" ]; then
+    echo NO OUTPUT IS FOUND
+    exit 1
+  fi
 
-    if [ "$isProcMacro" ]; then
-        pushd "target/${mode}"
-        for output in *; do
-            if [ -d "$output" ]; then
-                continue
-            fi
-            case $(extractFileExt "$output") in
-                so) ;&
-                dylib)
-                    isProcMacro=$(basename "$output")
-                    mkdir -p "$out/lib"
-                    cp "$output" "$out/lib"
-                    needs_deps=1
-                    has_output=1
-                    ;;
-                *)
-                    continue
-            esac
-        done
-        popd
-    fi
+  if [ "$needs_deps" ]; then
+    mkdir -p "$out/lib/deps"
+    linkExternCrateToDeps "$out/lib/deps" $dependencies
+  fi
 
-    if [ ! "$has_output" ]; then
-        echo NO OUTPUT IS FOUND
-        exit 1
-    fi
-
-    if [ "$needs_deps" ]; then
-        mkdir -p "$out/lib/deps"
-        linkExternCrateToDeps "$out/lib/deps" $dependencies
-    fi
-
-    echo {} | jq \
-        '{name:$name, metadata:$metadata, version:$version, proc_macro:$procmacro}' \
-        --arg name "$crateName" \
-        --arg metadata "$NIX_RUST_METADATA" \
-        --arg procmacro "$isProcMacro" \
-        --arg version "$version" > "$out/.cargo-info"
+  echo {} | jq \
+    '{name:$name, metadata:$metadata, version:$version, proc_macro:$procmacro}' \
+    --arg name "$crateName" \
+    --arg metadata "$NIX_RUST_METADATA" \
+    --arg procmacro "$isProcMacro" \
+    --arg version "$version" > "$out/.cargo-info"
 }
 
 cargoVerbosityLevel() {

--- a/overlay/utils.sh
+++ b/overlay/utils.sh
@@ -1,20 +1,24 @@
 # shellcheck shell=bash
+
 extractFileExt() {
-    local name=`basename $1`
-    echo ${name##*.}
+    local name=$(basename "$1")
+    echo "${name##*.}"
 }
+
 extractHash() {
-    local name=`basename $1`
-    echo ${name%%-*}
+    local name=$(basename "$1")
+    echo "${name%%-*}"
 }
+
 makeExternCrateFlags() {
-    local i=
     for (( i=1; i<$#; i+=2 )); do
         local extern_name="${@:$i:1}"
         local crate="${@:((i+1)):1}"
         [ -f "$crate/.cargo-info" ] || continue
-        local crate_name=`jq -r '.name' $crate/.cargo-info`
-        local proc_macro=`jq -r '.proc_macro' $crate/.cargo-info`
+
+        local crate_name=$(jq -r '.name' "$crate/.cargo-info")
+        local proc_macro=$(jq -r '.proc_macro' "$crate/.cargo-info")
+
         if [ "$proc_macro" ]; then
             echo "--extern" "${extern_name}=$crate/lib/$proc_macro"
         elif [ -f "$crate/lib/lib${crate_name}.rlib" ]; then
@@ -26,60 +30,69 @@ makeExternCrateFlags() {
         elif [ -f "$crate/lib/lib${crate_name}.dylib" ]; then
             echo "--extern" "${extern_name}=$crate/lib/lib${crate_name}.dylib"
         else
-            echo do not know how to find $extern_name \($crate_name\) >&2
+            echo "do not know how to find $extern_name ($crate_name)" >&2
             exit 1
         fi
-        echo "-L" dependency=$crate/lib/deps
+
+        echo "-L dependency=$crate/lib/deps"
         if [ -f "$crate/lib/.link-flags" ]; then
-            cat $crate/lib/.link-flags
+            cat "$crate/lib/.link-flags"
         fi
     done
 }
+
 loadExternCrateLinkFlags() {
-    local i=
     for (( i=1; i<$#; i+=2 )); do
         local extern_name="${@:$i:1}"
         local crate="${@:((i+1)):1}"
         [ -f "$crate/.cargo-info" ] || continue
-        local crate_name=`jq -r '.name' $crate/.cargo-info`
+
+        local crate_name=$(jq -r '.name' "$crate/.cargo-info")
         if [ -f "$crate/lib/.link-flags" ]; then
-            cat $crate/lib/.link-flags
+            cat "$crate/lib/.link-flags"
         fi
     done
 }
+
 loadDepKeys() {
     for (( i=2; i<=$#; i+=2 )); do
         local crate="${@:$i:1}"
         [ -f "$crate/.cargo-info" ] && [ -f "$crate/lib/.dep-keys" ] || continue
-        cat $crate/lib/.dep-keys
+        cat "$crate/lib/.dep-keys"
     done
 }
+
 linkExternCrateToDeps() {
     local deps_dir=$1; shift
     for (( i=1; i<$#; i+=2 )); do
         local dep="${@:((i+1)):1}"
         [ -f "$dep/.cargo-info" ] || continue
-        local crate_name=`jq -r '.name' $dep/.cargo-info`
-        local metadata=`jq -r '.metadata' $dep/.cargo-info`
-        local proc_macro=`jq -r '.proc_macro' $dep/.cargo-info`
+
+        local crate_name=$(jq -r '.name' "$dep/.cargo-info")
+        local metadata=$(jq -r '.metadata' "$dep/.cargo-info")
+        local proc_macro=$(jq -r '.proc_macro' "$dep/.cargo-info")
+
         if [ "$proc_macro" ]; then
-            local ext=`extractFileExt $proc_macro`
-            ln -sf $dep/lib/$proc_macro $deps_dir/`basename $proc_macro .$ext`-$metadata.$ext
+            local ext=$(extractFileExt "$proc_macro")
+            ln -sf "$dep/lib/$proc_macro" "$deps_dir/$(basename "$proc_macro.$ext")-$metadata.$ext"
         else
-            ln -sf $dep/lib/lib${crate_name}.rlib $deps_dir/lib${crate_name}-${metadata}.rlib
+            ln -sf "$dep/lib/lib${crate_name}.rlib" "$deps_dir/lib${crate_name}-${metadata}.rlib"
         fi
+
         (
             shopt -s nullglob
-            for subdep in $dep/lib/deps/*; do
-                local subdep_name=`basename $subdep`
-                ln -sf $subdep $deps_dir/$subdep_name
+            for subdep in "$dep/lib/deps"/*; do
+                local subdep_name=$(basename "$subdep")
+                ln -sf "$subdep" "$deps_dir/$subdep_name"
             done
         )
     done
 }
+
 upper() {
-    echo ${1^^}
+    echo "${1^^}"
 }
+
 dumpDepInfo() {
     local link_flags="$1"; shift
     local dep_keys="$1"; shift
@@ -87,7 +100,7 @@ dumpDepInfo() {
     local dep_files="$1"; shift
     local depinfo="$1"; shift
 
-    cat $depinfo | while read line; do
+    while read line; do
         [[ "x$line" =~ xcargo:([^=]+)=(.*) ]] || continue
         local key="${BASH_REMATCH[1]}"
         local val="${BASH_REMATCH[2]}"
@@ -102,17 +115,17 @@ dumpDepInfo() {
             warning)
             ;;
             rustc-link-search)
-                echo "-L" `printf '%q' $val` >>$link_flags
+                echo "-L $(printf '%q' "$val")" >> "$link_flags"
                 ;;
             *)
                 if [ -e "$val" ]; then
-                    local dep_file_target=$dep_files/DEP_$(upper $cargo_links)_$(upper $key)
-                    cp -r "$val" $dep_file_target
+                    local dep_file_target="$dep_files/DEP_$(upper "$cargo_links")_$(upper "$key")"
+                    cp -r "$val" "$dep_file_target"
                     val=$dep_file_target
                 fi
-                printf 'DEP_%s_%s=%s\n' $(upper $cargo_links) $(upper $key) "$val" >>$dep_keys
+                printf 'DEP_%s_%s=%s\n' "$(upper "$cargo_links")" "$(upper "$key")" "$val" >> "$dep_keys"
         esac
-    done
+    done < "$depinfo"
 }
 
 install_crate2() {
@@ -124,18 +137,18 @@ install_crate2() {
         | map(select(test("\\.(a|rlib|so|dylib)$")))
         | .[]' < .cargo-build-output) "$out/lib" 2> /dev/null || :
 
+    jq -rR 'fromjson?
+        | select(.reason == "build-script-executed")
+        | (.linked_libs | map("-l \(.)")) + (.linked_paths | map("-L \(.)"))
+        | .[]' < .cargo-build-output \
+        | tr '\n' ' ' >> "$out/lib/.link-flags"
+
     mkdir -p "$out/bin"
     # shellcheck disable=SC2046
     cp $(jq -rR 'fromjson?
         | select(.reason == "compiler-artifact")
         | .executable
         | select(.)' < .cargo-build-output) "$out/bin" 2> /dev/null || rmdir "$out/bin"
-
-    jq -rR 'fromjson?
-        | select(.reason == "build-script-executed")
-        | (.linked_libs | map("-l \(.)")) + (.linked_paths | map("-L \(.)"))
-        | .[]' < .cargo-build-output \
-        | tr '\n' ' ' >> "$out/lib/.link-flags"
 
     local out_dir
     if out_dir="$(jq -rR 'fromjson? | select(.reason == "build-script-executed") | .out_dir' < .cargo-build-output)"; then
@@ -160,52 +173,56 @@ install_crate2() {
         fi
     fi
 
-    loadExternCrateLinkFlags $dependencies >> $out/lib/.link-flags
+    loadExternCrateLinkFlags $dependencies >> "$out/lib/.link-flags"
 
-    if (shopt -s failglob; : $out/lib/*.rlib) 2>/dev/null; then
+    if (shopt -s failglob; : "$out/lib"/*.rlib) 2> /dev/null; then
         mkdir -p "$out/lib/deps"
         linkExternCrateToDeps "$out/lib/deps" $dependencies
     fi
 
     jq -n '{name:$name, metadata:$metadata, version:$version, proc_macro:$procmacro}' \
-        --arg name $crateName \
-        --arg metadata $NIX_RUST_METADATA \
+        --arg name "$crateName" \
+        --arg metadata "$NIX_RUST_METADATA" \
         --arg procmacro "$(basename "$(jq -rR 'fromjson? | select(.target.kind[0] == "proc-macro") | .filenames[0]' < .cargo-build-output)")" \
-        --arg version $version >$out/.cargo-info
+        --arg version "$version" > "$out/.cargo-info"
 }
 
 install_crate() {
-    local host_triple=$1
-    local mode=$2
-    pushd target/${host_triple}/${mode}
+    local host_triple="$1"
+    local mode="$2"
+    pushd "target/${host_triple}/${mode}"
+
     local needs_deps=
     local has_output=
     for output in *; do
         if [ -d "$output" ]; then
             continue
         elif [ -x "$output" ]; then
-            mkdir -p $out/bin
-            cp $output $out/bin/
+            mkdir -p "$out/bin"
+            cp "$output" "$out/bin/"
             has_output=1
         else
-            case `extractFileExt "$output"` in
+            case $(extractFileExt "$output") in
                 rlib)
-                    mkdir -p $out/lib/.dep-files
-                    cp $output $out/lib/
-                    local link_flags=$out/lib/.link-flags
-                    local dep_keys=$out/lib/.dep-keys
-                    touch $link_flags $dep_keys
+                    mkdir -p "$out/lib/.dep-files"
+                    cp "$output" "$out/lib/"
+
+                    local link_flags="$out/lib/.link-flags"
+                    local dep_keys="$out/lib/.dep-keys"
+                    touch "$link_flags" "$dep_keys"
+
                     for depinfo in build/*/output; do
-                        dumpDepInfo $link_flags $dep_keys "$cargo_links" $out/lib/.dep-files $depinfo
+                        dumpDepInfo "$link_flags" "$dep_keys" "$cargo_links" "$out/lib/.dep-files" "$depinfo"
                     done
+
                     needs_deps=1
                     has_output=1
                     ;;
                 a) ;&
                 so) ;&
                 dylib)
-                    mkdir -p $out/lib
-                    cp $output $out/lib/
+                    mkdir -p "$out/lib"
+                    cp "$output" "$out/lib/"
                     has_output=1
                     ;;
                 *)
@@ -215,21 +232,21 @@ install_crate() {
     done
     popd
 
-    touch $out/lib/.link-flags
-    loadExternCrateLinkFlags $dependencies >> $out/lib/.link-flags
+    touch "$out/lib/.link-flags"
+    loadExternCrateLinkFlags $dependencies >> "$out/lib/.link-flags"
 
     if [ "$isProcMacro" ]; then
-        pushd target/${mode}
+        pushd "target/${mode}"
         for output in *; do
             if [ -d "$output" ]; then
                 continue
             fi
-            case `extractFileExt "$output"` in
+            case $(extractFileExt "$output") in
                 so) ;&
                 dylib)
-                    isProcMacro=`basename $output`
-                    mkdir -p $out/lib
-                    cp $output $out/lib
+                    isProcMacro=$(basename "$output")
+                    mkdir -p "$out/lib"
+                    cp "$output" "$out/lib"
                     needs_deps=1
                     has_output=1
                     ;;
@@ -246,21 +263,21 @@ install_crate() {
     fi
 
     if [ "$needs_deps" ]; then
-        mkdir -p $out/lib/deps
-        linkExternCrateToDeps $out/lib/deps $dependencies
+        mkdir -p "$out/lib/deps"
+        linkExternCrateToDeps "$out/lib/deps" $dependencies
     fi
 
     echo {} | jq \
-'{name:$name, metadata:$metadata, version:$version, proc_macro:$procmacro}' \
---arg name $crateName \
---arg metadata $NIX_RUST_METADATA \
---arg procmacro "$isProcMacro" \
---arg version $version >$out/.cargo-info
+        '{name:$name, metadata:$metadata, version:$version, proc_macro:$procmacro}' \
+        --arg name "$crateName" \
+        --arg metadata "$NIX_RUST_METADATA" \
+        --arg procmacro "$isProcMacro" \
+        --arg version "$version" > "$out/.cargo-info"
 }
 
 cargoVerbosityLevel() {
-  level=${1:-0}
-  verbose_flag=""
+  local level=${1:-0}
+  local verbose_flag=""
 
   if (( level >= 1 )); then
     verbose_flag="-v"


### PR DESCRIPTION
### Changed

* Use `--message-format=json` to install artifacts on Rust >=1.41.0, falling back to the older method for compatibility with older versions of Rust that lack `out_dir` in the JSON output (https://github.com/rust-lang/cargo/pull/7622).
* Build examples in CI using the `HEAD` version of the overlay instead of the pinned versions, to actually check whether the current PR broke something.
* Address some `shellcheck` lints and clean up formatting of `overlay/utils.sh`.
* Lightly reorganize expression in `overlay/mkcrate.nix`.

This should hopefully fix the observed issues with recent versions (1.4X) of Rust placing test binaries in `target/deps` instead of `target`, thereby breaking the `install_crate` Bash function and the `cargo2nix` test runner.

@edude03 and @antigravityla, please confirm if `rustBuilder.runTests` now runs properly for you in CI with these changes!