### PR TITLE
Support for specifying target-feature and target-cpu for a package set

### DIFF
--- a/Cargo.nix
+++ b/Cargo.nix
@@ -9,6 +9,8 @@
   rustPackages,
   buildRustPackages,
   hostPlatform,
+  hostPlatformCpu ? null,
+  hostPlatformFeatures ? [],
   mkRustCrate,
   rustLib,
   lib,
@@ -35,7 +37,7 @@ in
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".aho-corasick."0.7.6" = overridableMkRustCrate (profileName: rec {
     name = "aho-corasick";
     version = "0.7.6";
@@ -49,7 +51,7 @@ in
       memchr = rustPackages."registry+https://github.com/rust-lang/crates.io-index".memchr."2.2.1" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".ansi_term."0.11.0" = overridableMkRustCrate (profileName: rec {
     name = "ansi_term";
     version = "0.11.0";
@@ -59,7 +61,7 @@ in
       ${ if hostPlatform.parsed.kernel.name == "windows" then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".atty."0.2.13" = overridableMkRustCrate (profileName: rec {
     name = "atty";
     version = "0.2.13";
@@ -70,14 +72,14 @@ in
       ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".autocfg."0.1.7" = overridableMkRustCrate (profileName: rec {
     name = "autocfg";
     version = "0.1.7";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".backtrace."0.3.40" = overridableMkRustCrate (profileName: rec {
     name = "backtrace";
     version = "0.3.40";
@@ -99,7 +101,7 @@ in
       rustc_demangle = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rustc-demangle."0.1.16" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".backtrace-sys."0.1.32" = overridableMkRustCrate (profileName: rec {
     name = "backtrace-sys";
     version = "0.1.32";
@@ -112,7 +114,7 @@ in
       cc = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.46" { profileName = "__noProfile"; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".bitflags."1.2.1" = overridableMkRustCrate (profileName: rec {
     name = "bitflags";
     version = "1.2.1";
@@ -122,7 +124,7 @@ in
       [ "default" ]
     ];
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".block-buffer."0.7.3" = overridableMkRustCrate (profileName: rec {
     name = "block-buffer";
     version = "0.7.3";
@@ -135,7 +137,7 @@ in
       generic_array = rustPackages."registry+https://github.com/rust-lang/crates.io-index".generic-array."0.12.3" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".block-padding."0.1.5" = overridableMkRustCrate (profileName: rec {
     name = "block-padding";
     version = "0.1.5";
@@ -145,7 +147,7 @@ in
       byte_tools = rustPackages."registry+https://github.com/rust-lang/crates.io-index".byte-tools."0.3.1" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".bstr."0.2.8" = overridableMkRustCrate (profileName: rec {
     name = "bstr";
     version = "0.2.8";
@@ -158,28 +160,28 @@ in
       memchr = rustPackages."registry+https://github.com/rust-lang/crates.io-index".memchr."2.2.1" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".byte-tools."0.3.1" = overridableMkRustCrate (profileName: rec {
     name = "byte-tools";
     version = "0.3.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".byteorder."1.3.4" = overridableMkRustCrate (profileName: rec {
     name = "byteorder";
     version = "1.3.4";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".bytesize."1.0.0" = overridableMkRustCrate (profileName: rec {
     name = "bytesize";
     version = "1.0.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "716960a18f978640f25101b5cbf1c6f6b0d3192fab36a2d98ca96f0ecbe41010"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".c2-chacha."0.2.3" = overridableMkRustCrate (profileName: rec {
     name = "c2-chacha";
     version = "0.2.3";
@@ -193,7 +195,7 @@ in
       ppv_lite86 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".ppv-lite86."0.2.6" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".cargo."0.41.0" = overridableMkRustCrate (profileName: rec {
     name = "cargo";
     version = "0.41.0";
@@ -255,7 +257,7 @@ in
       ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".cargo-platform."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "cargo-platform";
     version = "0.1.0";
@@ -265,7 +267,7 @@ in
       serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.104" { inherit profileName; };
     };
   });
-  
+
   "unknown".cargo2nix."0.8.3" = overridableMkRustCrate (profileName: rec {
     name = "cargo2nix";
     version = "0.8.3";
@@ -285,7 +287,7 @@ in
       toml = rustPackages."registry+https://github.com/rust-lang/crates.io-index".toml."0.5.3" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".cc."1.0.46" = overridableMkRustCrate (profileName: rec {
     name = "cc";
     version = "1.0.46";
@@ -301,14 +303,14 @@ in
       num_cpus = rustPackages."registry+https://github.com/rust-lang/crates.io-index".num_cpus."1.10.1" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10" = overridableMkRustCrate (profileName: rec {
     name = "cfg-if";
     version = "0.1.10";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".clap."2.33.0" = overridableMkRustCrate (profileName: rec {
     name = "clap";
     version = "2.33.0";
@@ -333,14 +335,14 @@ in
       vec_map = rustPackages."registry+https://github.com/rust-lang/crates.io-index".vec_map."0.8.1" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".colorify."0.2.3" = overridableMkRustCrate (profileName: rec {
     name = "colorify";
     version = "0.2.3";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "07ab9b64c78c2640c33acfa2384ac5329bd0a82b58e4d7b0bc622fe4e1e4ca65"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".commoncrypto."0.2.0" = overridableMkRustCrate (profileName: rec {
     name = "commoncrypto";
     version = "0.2.0";
@@ -350,7 +352,7 @@ in
       commoncrypto_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".commoncrypto-sys."0.2.0" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".commoncrypto-sys."0.2.0" = overridableMkRustCrate (profileName: rec {
     name = "commoncrypto-sys";
     version = "0.2.0";
@@ -360,7 +362,7 @@ in
       libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".core-foundation."0.6.4" = overridableMkRustCrate (profileName: rec {
     name = "core-foundation";
     version = "0.6.4";
@@ -374,7 +376,7 @@ in
       libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".core-foundation-sys."0.6.2" = overridableMkRustCrate (profileName: rec {
     name = "core-foundation-sys";
     version = "0.6.2";
@@ -384,7 +386,7 @@ in
       [ "mac_os_10_7_support" ]
     ];
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".crates-io."0.29.0" = overridableMkRustCrate (profileName: rec {
     name = "crates-io";
     version = "0.29.0";
@@ -400,7 +402,7 @@ in
       url = rustPackages."registry+https://github.com/rust-lang/crates.io-index".url."2.1.0" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".crc32fast."1.2.0" = overridableMkRustCrate (profileName: rec {
     name = "crc32fast";
     version = "1.2.0";
@@ -414,7 +416,7 @@ in
       cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".crossbeam-channel."0.3.9" = overridableMkRustCrate (profileName: rec {
     name = "crossbeam-channel";
     version = "0.3.9";
@@ -424,7 +426,7 @@ in
       crossbeam_utils = rustPackages."registry+https://github.com/rust-lang/crates.io-index".crossbeam-utils."0.6.6" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".crossbeam-utils."0.6.6" = overridableMkRustCrate (profileName: rec {
     name = "crossbeam-utils";
     version = "0.6.6";
@@ -440,7 +442,7 @@ in
       lazy_static = rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".crypto-hash."0.3.4" = overridableMkRustCrate (profileName: rec {
     name = "crypto-hash";
     version = "0.3.4";
@@ -453,7 +455,7 @@ in
       ${ if hostPlatform.parsed.kernel.name == "windows" then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".curl."0.4.25" = overridableMkRustCrate (profileName: rec {
     name = "curl";
     version = "0.4.25";
@@ -476,7 +478,7 @@ in
       ${ if hostPlatform.parsed.abi.name == "msvc" then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".curl-sys."0.4.23" = overridableMkRustCrate (profileName: rec {
     name = "curl-sys";
     version = "0.4.23";
@@ -502,7 +504,7 @@ in
       ${ if hostPlatform.parsed.abi.name == "msvc" || hostPlatform.parsed.abi.name == "msvc" then "vcpkg" else null } = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".vcpkg."0.2.7" { profileName = "__noProfile"; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".digest."0.8.1" = overridableMkRustCrate (profileName: rec {
     name = "digest";
     version = "0.8.1";
@@ -512,7 +514,7 @@ in
       generic_array = rustPackages."registry+https://github.com/rust-lang/crates.io-index".generic-array."0.12.3" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".env_logger."0.7.1" = overridableMkRustCrate (profileName: rec {
     name = "env_logger";
     version = "0.7.1";
@@ -533,7 +535,7 @@ in
       termcolor = rustPackages."registry+https://github.com/rust-lang/crates.io-index".termcolor."1.0.5" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".failure."0.1.6" = overridableMkRustCrate (profileName: rec {
     name = "failure";
     version = "0.1.6";
@@ -551,7 +553,7 @@ in
       failure_derive = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".failure_derive."0.1.6" { profileName = "__noProfile"; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".failure_derive."0.1.6" = overridableMkRustCrate (profileName: rec {
     name = "failure_derive";
     version = "0.1.6";
@@ -564,14 +566,14 @@ in
       synstructure = rustPackages."registry+https://github.com/rust-lang/crates.io-index".synstructure."0.12.1" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".fake-simd."0.1.2" = overridableMkRustCrate (profileName: rec {
     name = "fake-simd";
     version = "0.1.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".filetime."0.2.7" = overridableMkRustCrate (profileName: rec {
     name = "filetime";
     version = "0.2.7";
@@ -584,7 +586,7 @@ in
       ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".flate2."1.0.12" = overridableMkRustCrate (profileName: rec {
     name = "flate2";
     version = "1.0.12";
@@ -605,14 +607,14 @@ in
       miniz_oxide = rustPackages."registry+https://github.com/rust-lang/crates.io-index".miniz_oxide."0.3.3" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".fnv."1.0.6" = overridableMkRustCrate (profileName: rec {
     name = "fnv";
     version = "1.0.6";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".foreign-types."0.3.2" = overridableMkRustCrate (profileName: rec {
     name = "foreign-types";
     version = "0.3.2";
@@ -622,14 +624,14 @@ in
       foreign_types_shared = rustPackages."registry+https://github.com/rust-lang/crates.io-index".foreign-types-shared."0.1.1" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".foreign-types-shared."0.1.1" = overridableMkRustCrate (profileName: rec {
     name = "foreign-types-shared";
     version = "0.1.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".fs2."0.4.3" = overridableMkRustCrate (profileName: rec {
     name = "fs2";
     version = "0.4.3";
@@ -640,7 +642,7 @@ in
       ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".fwdansi."1.0.1" = overridableMkRustCrate (profileName: rec {
     name = "fwdansi";
     version = "1.0.1";
@@ -651,7 +653,7 @@ in
       termcolor = rustPackages."registry+https://github.com/rust-lang/crates.io-index".termcolor."1.0.5" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".generic-array."0.12.3" = overridableMkRustCrate (profileName: rec {
     name = "generic-array";
     version = "0.12.3";
@@ -661,7 +663,7 @@ in
       typenum = rustPackages."registry+https://github.com/rust-lang/crates.io-index".typenum."1.11.2" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".getrandom."0.1.12" = overridableMkRustCrate (profileName: rec {
     name = "getrandom";
     version = "0.1.12";
@@ -676,7 +678,7 @@ in
       ${ if hostPlatform.parsed.kernel.name == "wasi" || hostPlatform.parsed.kernel.name == "wasi" then "wasi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".wasi."0.7.0" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".git2."0.10.2" = overridableMkRustCrate (profileName: rec {
     name = "git2";
     version = "0.10.2";
@@ -700,7 +702,7 @@ in
       url = rustPackages."registry+https://github.com/rust-lang/crates.io-index".url."2.1.0" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".git2-curl."0.11.0" = overridableMkRustCrate (profileName: rec {
     name = "git2-curl";
     version = "0.11.0";
@@ -713,14 +715,14 @@ in
       url = rustPackages."registry+https://github.com/rust-lang/crates.io-index".url."2.1.0" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".glob."0.3.0" = overridableMkRustCrate (profileName: rec {
     name = "glob";
     version = "0.3.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".globset."0.4.4" = overridableMkRustCrate (profileName: rec {
     name = "globset";
     version = "0.4.4";
@@ -734,7 +736,7 @@ in
       regex = rustPackages."registry+https://github.com/rust-lang/crates.io-index".regex."1.3.1" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".globwalk."0.7.1" = overridableMkRustCrate (profileName: rec {
     name = "globwalk";
     version = "0.7.1";
@@ -745,14 +747,14 @@ in
       walkdir = rustPackages."registry+https://github.com/rust-lang/crates.io-index".walkdir."2.2.9" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".hex."0.3.2" = overridableMkRustCrate (profileName: rec {
     name = "hex";
     version = "0.3.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".hex."0.4.0" = overridableMkRustCrate (profileName: rec {
     name = "hex";
     version = "0.4.0";
@@ -763,7 +765,7 @@ in
       [ "std" ]
     ];
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".home."0.5.3" = overridableMkRustCrate (profileName: rec {
     name = "home";
     version = "0.5.3";
@@ -773,7 +775,7 @@ in
       ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".humantime."1.3.0" = overridableMkRustCrate (profileName: rec {
     name = "humantime";
     version = "1.3.0";
@@ -783,7 +785,7 @@ in
       quick_error = rustPackages."registry+https://github.com/rust-lang/crates.io-index".quick-error."1.2.2" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".idna."0.2.0" = overridableMkRustCrate (profileName: rec {
     name = "idna";
     version = "0.2.0";
@@ -795,7 +797,7 @@ in
       unicode_normalization = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-normalization."0.1.8" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".ignore."0.4.10" = overridableMkRustCrate (profileName: rec {
     name = "ignore";
     version = "0.4.10";
@@ -814,7 +816,7 @@ in
       ${ if hostPlatform.isWindows then "winapi_util" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi-util."0.1.2" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".im-rc."13.0.0" = overridableMkRustCrate (profileName: rec {
     name = "im-rc";
     version = "13.0.0";
@@ -828,7 +830,7 @@ in
       rustc_version = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".rustc_version."0.2.3" { profileName = "__noProfile"; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".itoa."0.4.4" = overridableMkRustCrate (profileName: rec {
     name = "itoa";
     version = "0.4.4";
@@ -839,7 +841,7 @@ in
       [ "std" ]
     ];
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".jobserver."0.1.17" = overridableMkRustCrate (profileName: rec {
     name = "jobserver";
     version = "0.1.17";
@@ -851,21 +853,21 @@ in
       log = rustPackages."registry+https://github.com/rust-lang/crates.io-index".log."0.4.8" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" = overridableMkRustCrate (profileName: rec {
     name = "lazy_static";
     version = "1.4.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".lazycell."1.2.1" = overridableMkRustCrate (profileName: rec {
     name = "lazycell";
     version = "1.2.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" = overridableMkRustCrate (profileName: rec {
     name = "libc";
     version = "0.2.65";
@@ -876,7 +878,7 @@ in
       [ "std" ]
     ];
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".libgit2-sys."0.9.2" = overridableMkRustCrate (profileName: rec {
     name = "libgit2-sys";
     version = "0.9.2";
@@ -900,7 +902,7 @@ in
       pkg_config = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".pkg-config."0.3.16" { profileName = "__noProfile"; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".libnghttp2-sys."0.1.2" = overridableMkRustCrate (profileName: rec {
     name = "libnghttp2-sys";
     version = "0.1.2";
@@ -913,7 +915,7 @@ in
       cc = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".cc."1.0.46" { profileName = "__noProfile"; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".libssh2-sys."0.2.13" = overridableMkRustCrate (profileName: rec {
     name = "libssh2-sys";
     version = "0.2.13";
@@ -930,7 +932,7 @@ in
       ${ if hostPlatform.parsed.abi.name == "msvc" then "vcpkg" else null } = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".vcpkg."0.2.7" { profileName = "__noProfile"; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".libz-sys."1.0.25" = overridableMkRustCrate (profileName: rec {
     name = "libz-sys";
     version = "1.0.25";
@@ -945,7 +947,7 @@ in
       ${ if hostPlatform.parsed.abi.name == "msvc" then "vcpkg" else null } = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".vcpkg."0.2.7" { profileName = "__noProfile"; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".log."0.4.8" = overridableMkRustCrate (profileName: rec {
     name = "log";
     version = "0.4.8";
@@ -958,21 +960,21 @@ in
       cfg_if = rustPackages."registry+https://github.com/rust-lang/crates.io-index".cfg-if."0.1.10" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".maplit."1.0.2" = overridableMkRustCrate (profileName: rec {
     name = "maplit";
     version = "1.0.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".matches."0.1.8" = overridableMkRustCrate (profileName: rec {
     name = "matches";
     version = "0.1.8";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".memchr."2.2.1" = overridableMkRustCrate (profileName: rec {
     name = "memchr";
     version = "2.2.1";
@@ -983,7 +985,7 @@ in
       [ "use_std" ]
     ];
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".miniz_oxide."0.3.3" = overridableMkRustCrate (profileName: rec {
     name = "miniz_oxide";
     version = "0.3.3";
@@ -993,7 +995,7 @@ in
       adler32 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".adler32."1.0.4" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".miow."0.3.3" = overridableMkRustCrate (profileName: rec {
     name = "miow";
     version = "0.3.3";
@@ -1004,7 +1006,7 @@ in
       winapi = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".num_cpus."1.10.1" = overridableMkRustCrate (profileName: rec {
     name = "num_cpus";
     version = "1.10.1";
@@ -1014,14 +1016,14 @@ in
       libc = rustPackages."registry+https://github.com/rust-lang/crates.io-index".libc."0.2.65" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".opaque-debug."0.2.3" = overridableMkRustCrate (profileName: rec {
     name = "opaque-debug";
     version = "0.2.3";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".opener."0.4.1" = overridableMkRustCrate (profileName: rec {
     name = "opener";
     version = "0.4.1";
@@ -1031,7 +1033,7 @@ in
       ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".openssl."0.10.25" = overridableMkRustCrate (profileName: rec {
     name = "openssl";
     version = "0.10.25";
@@ -1046,14 +1048,14 @@ in
       openssl_sys = rustPackages."registry+https://github.com/rust-lang/crates.io-index".openssl-sys."0.9.52" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".openssl-probe."0.1.2" = overridableMkRustCrate (profileName: rec {
     name = "openssl-probe";
     version = "0.1.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".openssl-sys."0.9.52" = overridableMkRustCrate (profileName: rec {
     name = "openssl-sys";
     version = "0.9.52";
@@ -1069,21 +1071,21 @@ in
       ${ if hostPlatform.parsed.abi.name == "msvc" then "vcpkg" else null } = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".vcpkg."0.2.7" { profileName = "__noProfile"; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".pathdiff."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "pathdiff";
     version = "0.1.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "a3bf70094d203e07844da868b634207e71bfab254fe713171fae9a6e751ccf31"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".percent-encoding."2.1.0" = overridableMkRustCrate (profileName: rec {
     name = "percent-encoding";
     version = "2.1.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".pest."2.1.2" = overridableMkRustCrate (profileName: rec {
     name = "pest";
     version = "2.1.2";
@@ -1093,7 +1095,7 @@ in
       ucd_trie = rustPackages."registry+https://github.com/rust-lang/crates.io-index".ucd-trie."0.1.2" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".pest_derive."2.1.0" = overridableMkRustCrate (profileName: rec {
     name = "pest_derive";
     version = "2.1.0";
@@ -1104,7 +1106,7 @@ in
       pest_generator = rustPackages."registry+https://github.com/rust-lang/crates.io-index".pest_generator."2.1.1" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".pest_generator."2.1.1" = overridableMkRustCrate (profileName: rec {
     name = "pest_generator";
     version = "2.1.1";
@@ -1118,7 +1120,7 @@ in
       syn = rustPackages."registry+https://github.com/rust-lang/crates.io-index".syn."1.0.5" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".pest_meta."2.1.2" = overridableMkRustCrate (profileName: rec {
     name = "pest_meta";
     version = "2.1.2";
@@ -1132,14 +1134,14 @@ in
       sha1 = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".sha-1."0.8.2" { profileName = "__noProfile"; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".pkg-config."0.3.16" = overridableMkRustCrate (profileName: rec {
     name = "pkg-config";
     version = "0.3.16";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".ppv-lite86."0.2.6" = overridableMkRustCrate (profileName: rec {
     name = "ppv-lite86";
     version = "0.2.6";
@@ -1150,7 +1152,7 @@ in
       [ "std" ]
     ];
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.5" = overridableMkRustCrate (profileName: rec {
     name = "proc-macro2";
     version = "1.0.5";
@@ -1164,14 +1166,14 @@ in
       unicode_xid = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-xid."0.2.0" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".quick-error."1.2.2" = overridableMkRustCrate (profileName: rec {
     name = "quick-error";
     version = "1.2.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".quote."1.0.2" = overridableMkRustCrate (profileName: rec {
     name = "quote";
     version = "1.0.2";
@@ -1185,7 +1187,7 @@ in
       proc_macro2 = rustPackages."registry+https://github.com/rust-lang/crates.io-index".proc-macro2."1.0.5" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".rand."0.7.2" = overridableMkRustCrate (profileName: rec {
     name = "rand";
     version = "0.7.2";
@@ -1206,7 +1208,7 @@ in
       ${ if hostPlatform.parsed.kernel.name == "emscripten" then "rand_hc" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rand_hc."0.2.0" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".rand_chacha."0.2.1" = overridableMkRustCrate (profileName: rec {
     name = "rand_chacha";
     version = "0.2.1";
@@ -1220,7 +1222,7 @@ in
       rand_core = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rand_core."0.5.1" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".rand_core."0.5.1" = overridableMkRustCrate (profileName: rec {
     name = "rand_core";
     version = "0.5.1";
@@ -1235,7 +1237,7 @@ in
       getrandom = rustPackages."registry+https://github.com/rust-lang/crates.io-index".getrandom."0.1.12" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".rand_hc."0.2.0" = overridableMkRustCrate (profileName: rec {
     name = "rand_hc";
     version = "0.2.0";
@@ -1245,14 +1247,14 @@ in
       rand_core = rustPackages."registry+https://github.com/rust-lang/crates.io-index".rand_core."0.5.1" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".redox_syscall."0.1.56" = overridableMkRustCrate (profileName: rec {
     name = "redox_syscall";
     version = "0.1.56";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".regex."1.3.1" = overridableMkRustCrate (profileName: rec {
     name = "regex";
     version = "1.3.1";
@@ -1285,7 +1287,7 @@ in
       thread_local = rustPackages."registry+https://github.com/rust-lang/crates.io-index".thread_local."0.3.6" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".regex-syntax."0.6.12" = overridableMkRustCrate (profileName: rec {
     name = "regex-syntax";
     version = "0.6.12";
@@ -1301,7 +1303,7 @@ in
       [ "unicode-segment" ]
     ];
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".remove_dir_all."0.5.2" = overridableMkRustCrate (profileName: rec {
     name = "remove_dir_all";
     version = "0.5.2";
@@ -1311,21 +1313,21 @@ in
       ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".rustc-demangle."0.1.16" = overridableMkRustCrate (profileName: rec {
     name = "rustc-demangle";
     version = "0.1.16";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".rustc-workspace-hack."1.0.0" = overridableMkRustCrate (profileName: rec {
     name = "rustc-workspace-hack";
     version = "1.0.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "fc71d2faa173b74b232dedc235e3ee1696581bb132fc116fa3626d6151a1a8fb"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".rustc_version."0.2.3" = overridableMkRustCrate (profileName: rec {
     name = "rustc_version";
     version = "0.2.3";
@@ -1335,7 +1337,7 @@ in
       semver = rustPackages."registry+https://github.com/rust-lang/crates.io-index".semver."0.9.0" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".rustfix."0.4.6" = overridableMkRustCrate (profileName: rec {
     name = "rustfix";
     version = "0.4.6";
@@ -1348,14 +1350,14 @@ in
       serde_json = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.41" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".ryu."1.0.2" = overridableMkRustCrate (profileName: rec {
     name = "ryu";
     version = "1.0.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".same-file."1.0.5" = overridableMkRustCrate (profileName: rec {
     name = "same-file";
     version = "1.0.5";
@@ -1365,7 +1367,7 @@ in
       ${ if hostPlatform.isWindows then "winapi_util" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi-util."0.1.2" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".schannel."0.1.16" = overridableMkRustCrate (profileName: rec {
     name = "schannel";
     version = "0.1.16";
@@ -1376,7 +1378,7 @@ in
       winapi = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".semver."0.9.0" = overridableMkRustCrate (profileName: rec {
     name = "semver";
     version = "0.9.0";
@@ -1391,14 +1393,14 @@ in
       serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.104" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".semver-parser."0.7.0" = overridableMkRustCrate (profileName: rec {
     name = "semver-parser";
     version = "0.7.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".serde."1.0.104" = overridableMkRustCrate (profileName: rec {
     name = "serde";
     version = "1.0.104";
@@ -1414,7 +1416,7 @@ in
       serde_derive = buildRustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_derive."1.0.104" { profileName = "__noProfile"; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".serde_derive."1.0.104" = overridableMkRustCrate (profileName: rec {
     name = "serde_derive";
     version = "1.0.104";
@@ -1429,7 +1431,7 @@ in
       syn = rustPackages."registry+https://github.com/rust-lang/crates.io-index".syn."1.0.5" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".serde_ignored."0.1.1" = overridableMkRustCrate (profileName: rec {
     name = "serde_ignored";
     version = "0.1.1";
@@ -1439,7 +1441,7 @@ in
       serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.104" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.41" = overridableMkRustCrate (profileName: rec {
     name = "serde_json";
     version = "1.0.41";
@@ -1455,7 +1457,7 @@ in
       serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.104" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".sha-1."0.8.2" = overridableMkRustCrate (profileName: rec {
     name = "sha-1";
     version = "0.8.2";
@@ -1468,14 +1470,14 @@ in
       opaque_debug = rustPackages."registry+https://github.com/rust-lang/crates.io-index".opaque-debug."0.2.3" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".shell-escape."0.1.4" = overridableMkRustCrate (profileName: rec {
     name = "shell-escape";
     version = "0.1.4";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "170a13e64f2a51b77a45702ba77287f5c6829375b04a69cf2222acd17d0cfab9"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".sized-chunks."0.3.1" = overridableMkRustCrate (profileName: rec {
     name = "sized-chunks";
     version = "0.3.1";
@@ -1485,7 +1487,7 @@ in
       typenum = rustPackages."registry+https://github.com/rust-lang/crates.io-index".typenum."1.11.2" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".smallvec."0.6.10" = overridableMkRustCrate (profileName: rec {
     name = "smallvec";
     version = "0.6.10";
@@ -1496,7 +1498,7 @@ in
       [ "std" ]
     ];
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".socket2."0.3.11" = overridableMkRustCrate (profileName: rec {
     name = "socket2";
     version = "0.3.11";
@@ -1509,7 +1511,7 @@ in
       ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".strip-ansi-escapes."0.1.0" = overridableMkRustCrate (profileName: rec {
     name = "strip-ansi-escapes";
     version = "0.1.0";
@@ -1519,14 +1521,14 @@ in
       vte = rustPackages."registry+https://github.com/rust-lang/crates.io-index".vte."0.3.3" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".strsim."0.8.0" = overridableMkRustCrate (profileName: rec {
     name = "strsim";
     version = "0.8.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".syn."1.0.5" = overridableMkRustCrate (profileName: rec {
     name = "syn";
     version = "1.0.5";
@@ -1549,7 +1551,7 @@ in
       unicode_xid = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-xid."0.2.0" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".synstructure."0.12.1" = overridableMkRustCrate (profileName: rec {
     name = "synstructure";
     version = "0.12.1";
@@ -1562,7 +1564,7 @@ in
       unicode_xid = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-xid."0.2.0" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".tar."0.4.26" = overridableMkRustCrate (profileName: rec {
     name = "tar";
     version = "0.4.26";
@@ -1574,7 +1576,7 @@ in
       ${ if hostPlatform.parsed.kernel.name == "redox" then "syscall" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".redox_syscall."0.1.56" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".tempfile."3.1.0" = overridableMkRustCrate (profileName: rec {
     name = "tempfile";
     version = "3.1.0";
@@ -1589,7 +1591,7 @@ in
       ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".tera."1.0.2" = overridableMkRustCrate (profileName: rec {
     name = "tera";
     version = "1.0.2";
@@ -1605,7 +1607,7 @@ in
       serde_json = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.41" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".termcolor."1.0.5" = overridableMkRustCrate (profileName: rec {
     name = "termcolor";
     version = "1.0.5";
@@ -1615,7 +1617,7 @@ in
       ${ if hostPlatform.isWindows then "wincolor" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".wincolor."1.0.2" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".textwrap."0.11.0" = overridableMkRustCrate (profileName: rec {
     name = "textwrap";
     version = "0.11.0";
@@ -1625,7 +1627,7 @@ in
       unicode_width = rustPackages."registry+https://github.com/rust-lang/crates.io-index".unicode-width."0.1.6" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".thread_local."0.3.6" = overridableMkRustCrate (profileName: rec {
     name = "thread_local";
     version = "0.3.6";
@@ -1635,7 +1637,7 @@ in
       lazy_static = rustPackages."registry+https://github.com/rust-lang/crates.io-index".lazy_static."1.4.0" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".toml."0.5.3" = overridableMkRustCrate (profileName: rec {
     name = "toml";
     version = "0.5.3";
@@ -1648,14 +1650,14 @@ in
       serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.104" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".typenum."1.11.2" = overridableMkRustCrate (profileName: rec {
     name = "typenum";
     version = "1.11.2";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".ucd-trie."0.1.2" = overridableMkRustCrate (profileName: rec {
     name = "ucd-trie";
     version = "0.1.2";
@@ -1666,7 +1668,7 @@ in
       [ "std" ]
     ];
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".unicode-bidi."0.3.4" = overridableMkRustCrate (profileName: rec {
     name = "unicode-bidi";
     version = "0.3.4";
@@ -1679,7 +1681,7 @@ in
       matches = rustPackages."registry+https://github.com/rust-lang/crates.io-index".matches."0.1.8" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".unicode-normalization."0.1.8" = overridableMkRustCrate (profileName: rec {
     name = "unicode-normalization";
     version = "0.1.8";
@@ -1689,7 +1691,7 @@ in
       smallvec = rustPackages."registry+https://github.com/rust-lang/crates.io-index".smallvec."0.6.10" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".unicode-width."0.1.6" = overridableMkRustCrate (profileName: rec {
     name = "unicode-width";
     version = "0.1.6";
@@ -1699,7 +1701,7 @@ in
       [ "default" ]
     ];
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".unicode-xid."0.2.0" = overridableMkRustCrate (profileName: rec {
     name = "unicode-xid";
     version = "0.2.0";
@@ -1709,7 +1711,7 @@ in
       [ "default" ]
     ];
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".url."2.1.0" = overridableMkRustCrate (profileName: rec {
     name = "url";
     version = "2.1.0";
@@ -1721,28 +1723,28 @@ in
       percent_encoding = rustPackages."registry+https://github.com/rust-lang/crates.io-index".percent-encoding."2.1.0" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".utf8parse."0.1.1" = overridableMkRustCrate (profileName: rec {
     name = "utf8parse";
     version = "0.1.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".vcpkg."0.2.7" = overridableMkRustCrate (profileName: rec {
     name = "vcpkg";
     version = "0.2.7";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".vec_map."0.8.1" = overridableMkRustCrate (profileName: rec {
     name = "vec_map";
     version = "0.8.1";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".vte."0.3.3" = overridableMkRustCrate (profileName: rec {
     name = "vte";
     version = "0.3.3";
@@ -1752,7 +1754,7 @@ in
       utf8parse = rustPackages."registry+https://github.com/rust-lang/crates.io-index".utf8parse."0.1.1" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".walkdir."2.2.9" = overridableMkRustCrate (profileName: rec {
     name = "walkdir";
     version = "2.2.9";
@@ -1764,7 +1766,7 @@ in
       ${ if hostPlatform.isWindows then "winapi_util" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi-util."0.1.2" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".wasi."0.7.0" = overridableMkRustCrate (profileName: rec {
     name = "wasi";
     version = "0.7.0";
@@ -1775,7 +1777,7 @@ in
       [ "default" ]
     ];
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" = overridableMkRustCrate (profileName: rec {
     name = "winapi";
     version = "0.3.8";
@@ -1826,14 +1828,14 @@ in
       ${ if hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" || hostPlatform.config == "x86_64-pc-windows-gnu" then "winapi_x86_64_pc_windows_gnu" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi-x86_64-pc-windows-gnu."0.4.0" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".winapi-i686-pc-windows-gnu."0.4.0" = overridableMkRustCrate (profileName: rec {
     name = "winapi-i686-pc-windows-gnu";
     version = "0.4.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".winapi-util."0.1.2" = overridableMkRustCrate (profileName: rec {
     name = "winapi-util";
     version = "0.1.2";
@@ -1843,14 +1845,14 @@ in
       ${ if hostPlatform.isWindows then "winapi" else null } = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi."0.3.8" { inherit profileName; };
     };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".winapi-x86_64-pc-windows-gnu."0.4.0" = overridableMkRustCrate (profileName: rec {
     name = "winapi-x86_64-pc-windows-gnu";
     version = "0.4.0";
     registry = "registry+https://github.com/rust-lang/crates.io-index";
     src = fetchCratesIo { inherit name version; sha256 = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"; };
   });
-  
+
   "registry+https://github.com/rust-lang/crates.io-index".wincolor."1.0.2" = overridableMkRustCrate (profileName: rec {
     name = "wincolor";
     version = "1.0.2";
@@ -1861,5 +1863,5 @@ in
       winapi_util = rustPackages."registry+https://github.com/rust-lang/crates.io-index".winapi-util."0.1.2" { inherit profileName; };
     };
   });
-  
+
 }

--- a/default.nix
+++ b/default.nix
@@ -43,6 +43,14 @@ let
   #     The default behavior is to activate all crates with default features.
   # - `fetchCrateAlternativeRegistry` (optional): A fetcher for crates on alternative registries.
   # - `release` (optional): Whether to enable release mode (equivalent to `cargo build --release`), defaults to `true`.
+  # - `hostPlatformCpu` (optional):
+  #     Equivalent to rust's target-cpu codegen option. If specified "-Ctarget-cpu=<value>" will be added to the set of rust
+  #     flags used for compilation of the package set.
+  # - `hostPlatformFeatures` (optional):
+  #     Equivalent to rust's target-feature codegen option. If specified "-Ctarget-feature=<values>" will be added to the set of rust
+  #     flags used for compilation of the package set. The value should be a list of the features to be turned on, without the leading "+",
+  #     e.g. `[ "aes" "sse2" "ssse3" "sse4.1" ]`.  They will be prefixed with a "+", and comma delimited before passing through to rust.
+  #     Crates that check for CPU features such as the `aes` crate will be evaluated against this argument.
   rustPkgs = pkgs.rustBuilder.makePackageSet' {
     rustChannel = "1.37.0";
     packageFun = import ./Cargo.nix;

--- a/overlay/make-package-set/full.nix
+++ b/overlay/make-package-set/full.nix
@@ -17,6 +17,8 @@
   fetchCrateAlternativeRegistry ? _: throw "fetchCrateAlternativeRegistry is required, but not specified in makePackageSet",
   release ? null,
   rootFeatures ? null,
+  hostPlatformCpu ? null,
+  hostPlatformFeatures ? [],
 }:
 lib.fix' (self:
   let
@@ -52,6 +54,8 @@ lib.fix' (self:
       };
       ${ if release == null then null else "release" } = release;
       ${ if rootFeatures == null then null else "rootFeatures" } = rootFeatures;
+      ${ if hostPlatformCpu == null then null else "hostPlatformCpu" } = hostPlatformCpu;
+      ${ if hostPlatformFeatures == null then null else "hostPlatformFeatures" } = hostPlatformFeatures;
     });
 
   in packageFunWith { mkRustCrate = mkRustCrate'; buildRustPackages = buildRustPackages'; } // {

--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -23,6 +23,8 @@
   meta ? { },
   rustcflags ? [ ],
   rustcBuildFlags ? [ ],
+  hostPlatformCpu ? null,
+  hostPlatformFeatures ? [],
   NIX_DEBUG ? 0,
 }:
 with builtins; with lib;
@@ -125,7 +127,10 @@ let
     buildDependencies = depMapToList buildDependencies;
     devDependencies = depMapToList (optionalAttrs (compileMode == "test") devDependencies);
 
-    extraRustcFlags = rustcflags;
+    extraRustcFlags =
+      optionals (hostPlatformCpu != null) ([("-Ctarget-cpu=" + hostPlatformCpu)]) ++
+      optionals (hostPlatformFeatures != []) [("-Ctarget-feature=" + (concatMapStringsSep "," (feature: "+" + feature) hostPlatformFeatures))] ++
+      rustcflags;
 
     extraRustcBuildFlags = rustcBuildFlags;
 

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -51,6 +51,10 @@ fn cfg_to_expr(cfg: &CfgExpr, platform_var: &str) -> BoolExpr {
             ("target_vendor", v) => {
                 Single(format!("{}.parsed.vendor.name == {:?}", platform_var, v))
             }
+            ("target_cpu", v) => Single(format!("{}Cpu == {:?}", platform_var, v)),
+            ("target_feature", v) => {
+                Single(format!("builtins.elem {:?} {}Features", v, platform_var,))
+            }
             _ => False,
         },
     }

--- a/templates/Cargo.nix.tera
+++ b/templates/Cargo.nix.tera
@@ -11,6 +11,8 @@
   rustPackages,
   buildRustPackages,
   hostPlatform,
+  hostPlatformCpu ? null,
+  hostPlatformFeatures ? [],
   mkRustCrate,
   rustLib,
   lib,
@@ -25,7 +27,7 @@ let
   rootFeatures' = expandFeatures rootFeatures;
   overridableMkRustCrate = f:
     let
-      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({ inherit release profile; } // (f profileName)));
+      drvs = genDrvsByProfile profilesByName ({ profile, profileName }: mkRustCrate ({ inherit release profile hostPlatformCpu hostPlatformFeatures; } // (f profileName)));
     in { compileMode ? null, profileName ? decideProfile compileMode release }:
       let drv = drvs.${profileName}; in if compileMode == null then drv else drv.override { inherit compileMode; };
 in


### PR DESCRIPTION
Howdy!

We're using cargo2nix, but ran into a snag. Our particular project makes use of AES via the "aes" crate. That particular crate uses conditions based on target-feature to decide whether to pull in a hardware-optimized crate, or use a software implementation instead:

```
[target.'cfg(not(all(target_feature="aes", target_feature = "sse2", any(target_arch = "x86_64", target_arch = "x86"))))'.dependencies]
aes-soft = { version = "0.4", path = "aes-soft" }
```

Today, cargo2nix doesn't support that.

I've created this PR to invite discussion about how that should be supported. For now, I've implemented a simple solution, but it isn't without drawbacks. The main one being that it is a breaking change currently, if this PR were adopted, folks using it would need to regenerate their Cargo.nix files to pick up the new `hostPlatformCpu` and `hostPlatformFeatures` variables.

I'm also not sure about the names of those variables, I picked them to split the difference between nix's `hostPlatform` concept, and rust's `target-cpu` and `target-feature` naming.

An example of using these new variables is as follows:

```
  rustPackages = super.rustBuilder.makePackageSet' {
    rustChannel = "stable";

    packageFun = import ./Cargo.nix;

    localPatterns = [
        # Standard included paths
        ''^(src|tests)(/.*)?''
        ''[^/]*\.(rs|toml)$''

        # Also include release-data folder
        ''^release-data(/.*)?''
    ];

    hostPlatformCpu = "sandybridge";

    hostPlatformFeatures = [
      "aes"
      "sse2"
      "ssse3"
      "sse4.1"
    ];
  };

```