### PR TITLE
Escape embedded TOML in profilesByName properly

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -31,6 +31,7 @@ impl BuildPlan {
         let profiles = profiles
             .into_iter()
             .map(|(name, profile)| (name, toml::to_string(&profile).unwrap()))
+            .map(|(name, toml)| (name, toml.replace("${", "\\${").escape_debug().to_string()))
             .collect();
 
         let workspace_members = root_pkgs


### PR DESCRIPTION
### Fixed

* Escape TOML output in `profilesByName` using a combination of `str::{escape_debug,replace}`.

The Tera templating code for `profilesByName` hadn't been rigorously tested, and as such, it didn't perform proper escaping of sensitive characters (e.g. `${`, `"`, and so on) before embedding the unsanitized TOML into a double-quoted Nix string in the `Cargo.nix`. This string might also contain newlines or other control characters which would need to be escaped as well.

This commit utilizes `String::escape_debug()` to perform the bulk of the escaping work, sanitizing common control characters such as `\n`, `\r`, and `\t`, and then we also replace all instances of `${` with `\${` to avoid accidental string interpolation of variables.

This bug was first introduced in #80, when we first ported `cargo2nix` to use Tera for templating.

Fixes #120. CC @philipstears