### PR TITLE
Fix broken nix-shell integration

### DIFF
--- a/overlay/mkcrate-nobuild.nix
+++ b/overlay/mkcrate-nobuild.nix
@@ -15,6 +15,8 @@
   meta ? { },
   rustcflags ? [ ],
   rustcBuildFlags ? [ ],
+  hostPlatformCpu ? null,
+  hostPlatformFeatures ? [],
 }:
 with lib; with builtins;
 let


### PR DESCRIPTION
### Fixed

* Add missing arguments to `mkcrate-nobuild.nix`, fixing an unforseen bug in #119.

Our existing `nix-shell` integration broke because the `hostPlatformCpu` and `hostPlatformFeatures` function arguments were missing from `overlay/mkcrate-nobuild.nix`. This commit adds those missing arguments back in so we can restore the broken functionality.