### PR TITLE
Remove unused sha256 argument for Git dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,6 @@ dependencies = [
  "pathdiff 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tera 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -281,7 +281,6 @@ in
       pathdiff = rustPackages."registry+https://github.com/rust-lang/crates.io-index".pathdiff."0.1.0" { inherit profileName; };
       semver = rustPackages."registry+https://github.com/rust-lang/crates.io-index".semver."0.9.0" { inherit profileName; };
       serde = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde."1.0.104" { inherit profileName; };
-      serde_json = rustPackages."registry+https://github.com/rust-lang/crates.io-index".serde_json."1.0.41" { inherit profileName; };
       tempfile = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tempfile."3.1.0" { inherit profileName; };
       tera = rustPackages."registry+https://github.com/rust-lang/crates.io-index".tera."1.0.2" { inherit profileName; };
       toml = rustPackages."registry+https://github.com/rust-lang/crates.io-index".toml."0.5.3" { inherit profileName; };

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ failure = "0.1.6"
 pathdiff = "0.1.0"
 semver = "0.9.0"
 serde = { version = "1.0.104", features = ["derive"] }
-serde_json = "1.0.41"
 tempfile = "3.1.0"
 tera = { version = "1.0.2", default-features = false }
 toml = "0.5.3"

--- a/default.nix
+++ b/default.nix
@@ -68,13 +68,7 @@ in
   #   `rustPkgs.workspace.<crate>`.
 rec {
   inherit rustPkgs;
-  package = (rustPkgs.workspace.cargo2nix { }).overrideAttrs (drv: {
-    nativeBuildInputs = drv.nativeBuildInputs or [ ] ++ [ pkgs.buildPackages.makeWrapper ];
-    installPhase = ''
-      ${drv.installPhase or ""}
-      wrapProgram $out/bin/cargo2nix --prefix PATH ":" "${pkgs.nix-prefetch-git}/bin"
-    '';
-  });
+  package = rustPkgs.workspace.cargo2nix {};
   # `runTests` runs all tests for a crate inside a Nix derivation.
   # This may be problematic as Nix may restrict filesystem, network access,
   # socket creation, ... which the test binary may need.

--- a/src/main.rs
+++ b/src/main.rs
@@ -413,29 +413,10 @@ impl<'a> ResolvedPackage<'a> {
             .map(|feature| (feature.as_str(), Optionality::default()))
             .collect();
 
-        let checksum = {
-            let checksum = resolve
-                .checksums()
-                .get(&pkg.package_id())
-                .and_then(|s| s.as_ref().map(Cow::from));
-
-            let source_id = pkg.package_id().source_id();
-            if checksum.is_none() && source_id.is_git() {
-                let url = source_id.url().as_str();
-                let rev = source_id.precise().ok_or_else(|| {
-                    failure::format_err!("no precise git reference for {}", pkg.package_id())
-                })?;
-                prefetch_git(url, rev)
-                    .map(Cow::Owned)
-                    .map(Some)
-                    .context(format!(
-                        "failed to compute SHA256 for {} using nix-prefetch-git",
-                        pkg.package_id(),
-                    ))?
-            } else {
-                checksum
-            }
-        };
+        let checksum = resolve
+            .checksums()
+            .get(&pkg.package_id())
+            .and_then(|s| s.as_ref().map(Cow::from));
 
         Ok(Self {
             pkg,
@@ -541,33 +522,6 @@ impl<'a> Optionality<'a> {
 
 fn display_root_feature((pkg_name, feature): RootFeature) -> String {
     format!("{}/{}", pkg_name, feature)
-}
-
-fn prefetch_git(url: &str, rev: &str) -> Result<String> {
-    use std::process::{Command, Output};
-
-    let Output {
-        stdout,
-        stderr,
-        status,
-    } = Command::new("nix-prefetch-git")
-        .arg("--quiet")
-        .args(&["--url", url])
-        .args(&["--rev", rev])
-        .output()?;
-
-    if status.success() {
-        serde_json::from_slice::<serde_json::Value>(&stdout)?
-            .get("sha256")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .ok_or_else(|| failure::format_err!("unexpected JSON output"))
-    } else {
-        Err(failure::format_err!(
-            "process failed with stderr {:?}",
-            String::from_utf8(stderr)
-        ))
-    }
 }
 
 fn all_eq<T, I>(i: I) -> bool

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 #![forbid(unsafe_code)]
 
 use std::{
-    borrow::Cow,
     collections::{BTreeMap, BTreeSet, HashMap},
     fs,
     io::{self, BufRead, Write},
@@ -362,7 +361,7 @@ pub struct ResolvedPackage<'a> {
     pkg: &'a Package,
     deps: BTreeMap<(PackageId, DependencyKind), ResolvedDependency<'a>>,
     features: BTreeMap<Feature<'a>, Optionality<'a>>,
-    checksum: Option<Cow<'a, str>>,
+    checksum: Option<&'a str>,
 }
 
 impl<'a> ResolvedPackage<'a> {
@@ -416,7 +415,7 @@ impl<'a> ResolvedPackage<'a> {
         let checksum = resolve
             .checksums()
             .get(&pkg.package_id())
-            .and_then(|s| s.as_ref().map(Cow::from));
+            .and_then(|opt| opt.as_ref().map(|s| s.as_str()));
 
         Ok(Self {
             pkg,

--- a/src/template.rs
+++ b/src/template.rs
@@ -89,21 +89,10 @@ pub struct Crate {
 
 #[derive(Debug, Serialize)]
 pub enum Source {
-    CratesIo {
-        sha256: String,
-    },
-    Git {
-        url: String,
-        rev: String,
-        sha256: String,
-    },
-    Local {
-        path: PathBuf,
-    },
-    Registry {
-        index: String,
-        sha256: String,
-    },
+    CratesIo { sha256: String },
+    Git { url: String, rev: String },
+    Local { path: PathBuf },
+    Registry { index: String, sha256: String },
 }
 
 #[derive(Debug, Serialize)]
@@ -154,13 +143,6 @@ fn to_source(pkg: &ResolvedPackage<'_>, cwd: &Path) -> Result<Source> {
                 .map(|p| p.to_string())
                 .ok_or_else(|| {
                     failure::format_err!("precise ref not found for git package {}", id)
-                })?,
-            sha256: pkg
-                .checksum
-                .as_ref()
-                .map(|c| c.to_string())
-                .ok_or_else(|| {
-                    failure::format_err!("checksum is required for git package {}", id)
                 })?,
         }
     } else if id.source_id().is_path() {

--- a/templates/Cargo.nix.tera
+++ b/templates/Cargo.nix.tera
@@ -53,7 +53,6 @@ in
       name = "{{ crate.name }}";
       version = "{{ crate.version }}";
       rev = "{{ crate.source.Git.rev }}";
-      sha256 = "{{ crate.source.Git.sha256 }}"; {# unused #}
     };
     {%- elif crate.source.Local.path %}
     src = fetchCrateLocal ./{{ crate.source.Local.path }};


### PR DESCRIPTION
### Changed

* Simplify `checksum` field of `ResolvedPackage` from `Option<Cow<'a, str>` to `Option<&'a str>`.

### Removed

* Remove unused `sha256` argument for Git dependencies.
* Remove `serde_json` dependency.
* Remove private `prefetch_git` function.
* Remove `nix-prefetch-git` wrapper from `default.nix`.

This argument has been rendered unused since the transition to `builtins.fetchGit` for all Git dependencies was made (#113). Since a minor release is coming soon, due to #119, this breaking change should now be safe to roll out.

Closes #102.