### PR TITLE
Fix install_crate behavior for debug builds

### DIFF
--- a/overlay/mkcrate.nix
+++ b/overlay/mkcrate.nix
@@ -236,7 +236,7 @@ let
     installPhase = ''
       mkdir -p $out/lib
       cargo_links="$(remarshal -if toml -of json Cargo.original.toml | jq -r '.package.links | select(. != null)')"
-      install_crate ${host-triple}
+      install_crate ${host-triple} ${if release then "release" else "debug"}
     '';
   };
 in

--- a/overlay/utils.sh
+++ b/overlay/utils.sh
@@ -116,7 +116,8 @@ dumpDepInfo() {
 
 install_crate() {
     local host_triple=$1
-    pushd target/${host_triple}/release
+    local mode=$2
+    pushd target/${host_triple}/${mode}
     local needs_deps=
     local has_output=
     for output in *; do
@@ -158,7 +159,7 @@ install_crate() {
     loadExternCrateLinkFlags $dependencies >> $out/lib/.link-flags
 
     if [ "$isProcMacro" ]; then
-        pushd target/release
+        pushd target/${mode}
         for output in *; do
             if [ -d "$output" ]; then
                 continue


### PR DESCRIPTION
### Fixed

* Switch to the `target/${triple}/release` or `target/${triple}/debug` directory when installing a crate, now properly respecting the `release` boolean flag.

Note that this fix should be rendered unnecessary by #118, but we still need to support older versions of Rust <1.41.0.