### PR TITLE
Validate shell.nix and mkcrate-nobuild.nix in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
             cachix push cargo2nix -w &
             nix-build -A ci --show-trace
             nix-build -A examples -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/47b551c6a854a049045455f8ab1b8750e7b00625.tar.gz --show-trace
+            nix-shell --show-trace --run exit
           no_output_timeout: 5h
       - save_cache:
           key: nix-store


### PR DESCRIPTION
### Changed

* Invoke `nix-shell` in CI to verify the validity of `shell.nix` and `overlay/mkcrate-nobuild.nix`.

We've been bitten by this before (#123), so I think this change would come in handy.