### PR TITLE
Fix fetcher for Git dependencies

### DIFF
--- a/overlay/lib/fetch.nix
+++ b/overlay/lib/fetch.nix
@@ -6,7 +6,7 @@ rec {
     inherit sha256;
   };
 
-  fetchCrateGit = { url, name, version, rev, sha256 }:
+  fetchCrateGit = { url, name, version, rev }:
     let
       inherit (buildPackages) runCommand jq remarshal;
       repo = builtins.fetchGit {


### PR DESCRIPTION
### Removed

* Remove leftover `sha256` argument from `fetchCrateGit`.

This argument was recently removed from the codegen side in #124, but unfortunately, the corresponding change to the Nix overlay were forgotten.

Fixes #132.