### PR TITLE
Upgrade nixpkgs-mozilla pins to fix CI with Rust 1.46

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,8 +4,8 @@
     sha256 = "0p0p6gf3kimcan4jgb4im3plm3yw68da09ywmyzhak8h64sgy4kg";
   },
   nixpkgsMozilla ? builtins.fetchTarball {
-    url = https://github.com/mozilla/nixpkgs-mozilla/archive/50bae918794d3c283aeb335b209efd71e75e3954.tar.gz;
-    sha256 = "07b7hgq5awhddcii88y43d38lncqq9c8b2px4p93r5l7z0phv89d";
+    url = https://github.com/mozilla/nixpkgs-mozilla/archive/18cd4300e9bf61c7b8b372f07af827f6ddc835bb.tar.gz;
+    sha256 = "1s0d1l5y7a3kygjbibssjnj7fcc87qaa5s9k4kda0j13j9h4zwgr";
   },
   system ? builtins.currentSystem,
   overlays ? [ ],

--- a/examples/1-hello-world/default.nix
+++ b/examples/1-hello-world/default.nix
@@ -2,7 +2,7 @@
   system ? builtins.currentSystem,
   nixpkgsMozilla ? builtins.fetchGit {
     url = https://github.com/mozilla/nixpkgs-mozilla;
-    rev = "50bae918794d3c283aeb335b209efd71e75e3954";
+    rev = "18cd4300e9bf61c7b8b372f07af827f6ddc835bb";
   },
   cargo2nix ? builtins.fetchGit {
     url = https://github.com/tenx-tech/cargo2nix;

--- a/examples/2-bigger-project/default.nix
+++ b/examples/2-bigger-project/default.nix
@@ -2,7 +2,7 @@
   system ? builtins.currentSystem,
   nixpkgsMozilla ? builtins.fetchGit {
     url = https://github.com/mozilla/nixpkgs-mozilla;
-    rev = "50bae918794d3c283aeb335b209efd71e75e3954";
+    rev = "18cd4300e9bf61c7b8b372f07af827f6ddc835bb";
   },
   cargo2nix ? builtins.fetchGit {
     url = https://github.com/tenx-tech/cargo2nix;

--- a/examples/3-static-resources/default.nix
+++ b/examples/3-static-resources/default.nix
@@ -2,7 +2,7 @@
   system ? builtins.currentSystem,
   nixpkgsMozilla ? builtins.fetchGit {
     url = https://github.com/mozilla/nixpkgs-mozilla;
-    rev = "50bae918794d3c283aeb335b209efd71e75e3954";
+    rev = "18cd4300e9bf61c7b8b372f07af827f6ddc835bb";
   },
   cargo2nix ? builtins.fetchGit {
     url = https://github.com/tenx-tech/cargo2nix;


### PR DESCRIPTION
### Fixed

* Upgrade `nixpkgs-mozilla` version pins to `18cd4300e9bf61c7b8b372f07af827f6ddc835bb`.

This includes an upstream fix for the missing `libz.so.1` error seen with Rust 1.46.0 (https://github.com/mozilla/nixpkgs-mozilla/commit/ab9b53ebbbf9fe803e0fd7718192e7f3ba2c7759). It should resolve the issue previously preventing CircleCI from passing in PR #141.