### PR TITLE
Update to nixpkgs 25.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,16 +54,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1705099185,
-        "narHash": "sha256-SxJenKtvcrKJd0TyJQMO3p6VA7PEp+vmMnmlKFzWMNs=",
+        "lastModified": 1755922037,
+        "narHash": "sha256-wY1+2JPH0ZZC4BQefoZw/k+3+DowFyfOxv17CN/idKs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2bce5ccff0ad7abda23e8bb56434b6877a446694",
+        "rev": "b1b3291469652d5a2edb0becc4ef0246fff97a7c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "release-23.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=release-23.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/overlay/overrides.nix
+++ b/overlay/overrides.nix
@@ -115,9 +115,7 @@ in rec {
     then makeOverride {
       name = "fsevent-sys";
       overrideAttrs = drv: {
-        propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [
-          pkgs.darwin.apple_sdk.frameworks.CoreServices
-        ];
+        propagatedBuildInputs = drv.propagatedBuildInputs or [ ];
       };
     }
     else  nullOverride;
@@ -126,9 +124,7 @@ in rec {
     then makeOverride {
       name = "reqwest";
       overrideAttrs = drv: {
-        propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [
-          pkgs.darwin.apple_sdk.frameworks.Security
-        ];
+        propagatedBuildInputs = drv.propagatedBuildInputs or [ ];
       };
     }
     else  nullOverride;
@@ -162,8 +158,6 @@ in rec {
       name = "libgit2-sys";
       overrideAttrs = drv: {
         propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [
-          pkgs.darwin.apple_sdk.frameworks.Security
-          pkgs.darwin.apple_sdk.frameworks.CoreFoundation
           pkgs.libgit2
         ];
         preferLocalBuild = true;
@@ -252,7 +246,7 @@ in rec {
     then makeOverride {
       name = "rand";
       overrideAttrs = drv: {
-        propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [ pkgs.darwin.apple_sdk.frameworks.Security ];
+        propagatedBuildInputs = drv.propagatedBuildInputs or [ ];
       };
     }
     else nullOverride;
@@ -261,7 +255,7 @@ in rec {
     then makeOverride {
       name = "rand_os";
       overrideAttrs = drv: {
-        propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [ pkgs.darwin.apple_sdk.frameworks.Security ];
+        propagatedBuildInputs = drv.propagatedBuildInputs or [ ];
       };
     }
     else nullOverride;
@@ -270,7 +264,7 @@ in rec {
   then makeOverride {
     name = "sqlx-macros";
     overrideAttrs = drv: {
-      propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [ pkgs.darwin.apple_sdk.frameworks.SystemConfiguration ];
+      propagatedBuildInputs = drv.propagatedBuildInputs or [ ];
     };
   }
   else nullOverride;
@@ -289,7 +283,7 @@ in rec {
     then makeOverride {
       name = "ring";
       overrideAttrs = drv: {
-        propagatedBuildInputs = drv.propagatedBuildInputs or [ ] ++ [ pkgs.darwin.apple_sdk.frameworks.Security ];
+        propagatedBuildInputs = drv.propagatedBuildInputs or [ ];
       };
     }
     else nullOverride;


### PR DESCRIPTION
^title. This PR moves from using nixpkgs `23.11` to `25.05`. This fixes the build on macOS. https://github.com/cargo2nix/cargo2nix/issues/399

I also fixed warnings from using some macOS specific packages that no longer have any effect.
