### PR TITLE
Update fetch.nix to use CDN URL [release-0.12 hotfix]

### DIFF
--- a/overlay/lib/fetch.nix
+++ b/overlay/lib/fetch.nix
@@ -2,7 +2,7 @@
 rec {
   fetchCratesIo = { name, version, sha256 }: buildPackages.fetchurl {
     name = "${name}-${version}.tar.gz";
-    url = "https://crates.io/api/v1/crates/${name}/${version}/download";
+    url = "https://static.crates.io/crates/${name}/${name}-${version}.crate";
     inherit sha256;
   };
 


### PR DESCRIPTION
# Summary

Some of our CI builds started failing while fetching crate tarballs, for example:

https://crates.io/api/v1/crates/adler2/2.0.1/download
curl: (22) The requested URL returned error: 403

The generated cargo2nix derivations use fetchCratesIo, so this avoids the API path and uses the canonical static crate tarball URL instead. The source remains content-addressed by sha256, so this should not change successful fetch output contents.

* Switch cargo2nix's crates.io fetch helper from the crates.io API download endpoint to static.crates.io
* Mirrors the nixpkgs fix from https://github.com/NixOS/nixpkgs/pull/524985 for recent crates.io 403/rate-limit behavior


